### PR TITLE
[usdAbc] fixed reading indexed attributes 

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -76,6 +76,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (transform)
     ((xformOpTransform, "xformOp:transform"))
+    ((indicesSuffix, ":indices"))
+    ((valuesSuffix, ":vals"))
 );
 
 TF_DEFINE_ENV_SETTING(
@@ -2156,18 +2158,36 @@ _PrimReaderContext::AddOutOfSchemaProperty(
     // Get the converter and add the property.
     const bool isOutOfSchema = true;
     const UsdAbc_AlembicType alembicType(*header);
-    const SdfValueTypeName usdTypeName =
+    SdfValueTypeName usdTypeName =
         _context.GetSchema().GetConversions().FindConverter(alembicType);
+
     if (usdTypeName) {
-        _PrimReaderContext::Property &prop = 
-            (TfGetEnvSetting(USD_ABC_WRITE_UV_AS_ST_TEXCOORD2FARRAY) && 
-             name == UsdAbcPropertyNames->uvIndices)? 
-                (_AddProperty(UsdAbcPropertyNames->stIndices, 
-                             usdTypeName, header->getMetaData(), 
-                             sampleTimes, isOutOfSchema)) :
-                (_AddProperty(TfToken(name), 
-                             usdTypeName, header->getMetaData(), 
-                             sampleTimes, isOutOfSchema)); 
+        TfToken propName(name);
+        if (TfGetEnvSetting(USD_ABC_WRITE_UV_AS_ST_TEXCOORD2FARRAY) &&
+            name == UsdAbcPropertyNames->uvIndices) {
+            propName = UsdAbcPropertyNames->stIndices;
+        }
+        else if (TfStringEndsWith(name, _tokens->indicesSuffix)){
+            // If the property is indexed and we're adding the indices here
+            // then we want to make sure they are added as an IntArray
+            // as that's the only supported type for index arrays.
+            usdTypeName = SdfValueTypeNames->IntArray;
+        }
+        else if (TfStringEndsWith(name, _tokens->valuesSuffix)) {
+            // If the property is indexed and we're adding the values
+            // it might have a ":vals" suffix. We need to remove it
+            // to be compatible.
+            propName = TfToken(name.substr(0, name.size() - _tokens->valuesSuffix.size()));
+        }
+
+        _PrimReaderContext::Property &prop = _AddProperty(
+            propName,
+            usdTypeName,
+            header->getMetaData(),
+            sampleTimes,
+            isOutOfSchema
+        );
+
         prop.converter = std::bind(
             _context.GetSchema().GetConversions().GetToUsdConverter(
                 alembicType, prop.typeName),

--- a/pxr/usd/plugin/usdAbc/alembicUtil.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.cpp
@@ -323,6 +323,7 @@ UsdAbc_AlembicConversions::UsdAbc_AlembicConversions()
     // Other conversions.
     data.AddConverter<int,          int8_t>();
     data.AddConverter<int,          int16_t>();
+    data.AddConverter<int,          uint32_t>();
     data.AddConverter<unsigned int, uint16_t>();
     data.AddConverter<TfToken,      std::string>();
     data.AddConverter<GfMatrix4d,   float32_t, 16>();

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcIndexedProperties/baseline/indexedTextureCoordinates.def.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcIndexedProperties/baseline/indexedTextureCoordinates.def.usda
@@ -53,8 +53,8 @@ def Mesh "Cube"
     uchar xform:ops.timeSamples = {
         0: 48,
     }
-    custom matrix4d xform:vals
-    matrix4d xform:vals.timeSamples = {
+    custom matrix4d xform
+    matrix4d xform.timeSamples = {
         0: ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) ),
     }
 }


### PR DESCRIPTION
### Description of Change(s)

- #860 : removed `:vals` name suffix for indexed attributes
- #859 : added support for indexed attributes using indices of type `uint[]` by converting to `int[]`
- updated `testUsdAbcIndexedProperties` baseline USD file

### Fixes Issue(s)
- #860 
- #859 

