### PR TITLE
cmake: added support for external libraries for pxr_python_bin

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -29,6 +29,7 @@ function(pxr_python_bin BIN_NAME)
     )
     set(multiValueArgs
         DEPENDENCIES
+        LIBRARIES
     )
     cmake_parse_arguments(pb
         ""
@@ -104,6 +105,10 @@ function(pxr_python_bin BIN_NAME)
         DEPENDS ${outputs} ${pb_DEPENDENCIES}
     )
     add_dependencies(python ${BIN_NAME}_script)
+
+    _pxr_target_link_libraries(${BIN_NAME}_script
+        ${pb_LIBRARIES}
+    )
 
     _get_folder("" folder)
     set_target_properties(${BIN_NAME}_script


### PR DESCRIPTION
### Description of Change(s)
 - cmake: added support for external libraries for pxr_python_bin

This is not yet needed in the vanilla pxr setup but it is in others like ours where we've split our USD build into separate builds.