### PR TITLE
Fix plugInfo reading when path contains regex characters

### DIFF
--- a/pxr/base/plug/info.cpp
+++ b/pxr/base/plug/info.cpp
@@ -304,6 +304,16 @@ _TranslateWildcardToRegex(const std::string& wildcard)
         case '.':
         case '[':
         case ']':
+        case '+':
+        case '?':
+        case '^':
+        case '$':
+        case '(':
+        case ')':
+        case '{':
+        case '}':
+        case '|':
+        case '\\':
             // Escaped literal.
             result.push_back('\\');
             result.push_back(c);
@@ -408,22 +418,21 @@ _ReadPlugInfoWithWildcards(_ReadContext* context, const std::string& pathname)
         return;
     }
 
-    // Converts backslashes to forward slashes for Windows.
-    std::string normalized = TfStringReplace(pathname, "\\", "/");
+    // Normalizes the path, replacing \ with / and removing . and ..
+    // ** won't be touched by this operation.
+    std::string normalized = TfNormPath(pathname);
 
     // Find longest non-wildcarded prefix directory.
-    std::string::size_type j = normalized.rfind('/', i);
-    std::string dirname = TfNormPath(normalized.substr(0, j));
-    std::string pattern = normalized.substr(j + 1);
+    std::string::size_type j = normalized.rfind('/', normalized.find("**"));
+    std::string dirname = normalized.substr(0, j);
 
     // Convert to regex.
-    pattern = _TranslateWildcardToRegex(pattern);
+    std::string pattern = _TranslateWildcardToRegex(normalized);
 
-    // Append implied filename and build full regex string.
-    pattern = TfStringPrintf("%s/%s%s",
-                             dirname.c_str(), pattern.c_str(),
-                             !pattern.empty() && *pattern.rbegin() == '/'
-                             ? _Tokens->PlugInfoName.GetText() : "");
+    // Append implied filename if need be.
+    if (!pattern.empty() && *pattern.rbegin() == '/') {
+        pattern.append(_Tokens->PlugInfoName.GetText());
+    }
 
     std::shared_ptr<std::regex> re;
     try {


### PR DESCRIPTION
### Description of Change(s)

The previous code was failing to glob plugInfo files when the path contained special characters such as parentheses. For instance, given the path
```
/foo(bar)/**/plugInfo.json
```
the previous code was generating a regex
```
/foo(bar)/.*/plugInfo.json
```
which was not matching anything. This commit escapes the entire path, including the non-wildcarded prefix. It also adds the missing special characters in the escape function.