### PR TITLE
Fix compatibility with TBB v2021.5

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -141,6 +141,9 @@ endif()
 # --TBB
 find_package(TBB REQUIRED COMPONENTS tbb)
 add_definitions(${TBB_DEFINITIONS})
+if ((${TBB_INTERFACE_VERSION} GREATER_EQUAL 12000) AND (${TBB_INTERFACE_VERSION} LESS_EQUAL 12050))
+    add_definitions(-DTBB_PREVIEW_TASK_GROUP_EXTENSIONS)
+endif()
 
 # --math
 if(WIN32)


### PR DESCRIPTION
### Description of Change(s)

Add compile definition TBB_PREVIEW_TASK_GROUP_EXTENSIONS when TBB version is between 12.000 and 12.050
This fixes a compile error when using TBB v2021.5, used by libtbb-dev in Ubuntu 22.04

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3514

### Checklist

[X] I have created this PR based on the dev branch

[ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[ ] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
