### PR TITLE
Ignore `CMakeUserPresets.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .p4*
 .DS_Store
 .AppleDouble
+/CMakeUserPresets.json
 


### PR DESCRIPTION
### Description of Change(s)

Adds `CMakeUserPresets.json` to the OpenUSD's `.gitignore`.

The cmake documentation recommends that this file be excluded from version control: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction

Even though OpenUSD does not use presets, other tooling around OpenUSD (such as `conan`) may generate this file.

Example of user presets being ignored in cmake's GitHub repo.
https://github.com/Kitware/CMake/blob/2a15023d441fd56a09e8a0b47a328b7ca0d73262/.gitignore#L4

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
