### PR TITLE
Add support for HgiVertexBufferStepFunctionPerInstance to OpenGL, Vulkan, and Metal

### DIFF
--- a/pxr/imaging/hgiGL/graphicsPipeline.cpp
+++ b/pxr/imaging/hgiGL/graphicsPipeline.cpp
@@ -82,6 +82,22 @@ HgiGLGraphicsPipeline::BindPipeline()
                         _vao,
                         vbo.bindingIndex,
                         std::numeric_limits<GLint>::max());
+                } else if (vbo.vertexStepFunction ==
+                                HgiVertexBufferStepFunctionPerInstance) {
+                    // Set the divisor such that the attribute index will
+                    // advance per instance
+                    glVertexArrayBindingDivisor(
+                        _vao,
+                        vbo.bindingIndex,
+                        1);
+                }
+                else {
+                    // Set the divisor such that the attribute index will
+                    // advance per vertex
+                    glVertexArrayBindingDivisor(
+                        _vao,
+                        vbo.bindingIndex,
+                        0);
                 }
             }
         }

--- a/pxr/imaging/hgiMetal/graphicsPipeline.mm
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.mm
@@ -79,6 +79,11 @@ HgiMetalGraphicsPipeline::_CreateVertexDescriptor()
             _vertexDescriptor.layouts[index].stepFunction =
                 MTLVertexStepFunctionPerPatchControlPoint;
             _vertexDescriptor.layouts[index].stepRate = 1;
+        } else if (vbo.vertexStepFunction ==
+                HgiVertexBufferStepFunctionPerInstance) {
+            _vertexDescriptor.layouts[index].stepFunction =
+                MTLVertexStepFunctionPerInstance;
+            _vertexDescriptor.layouts[index].stepRate = 1;
         }
         else {
             _vertexDescriptor.layouts[index].stepFunction =

--- a/pxr/imaging/hgiVulkan/graphicsPipeline.cpp
+++ b/pxr/imaging/hgiVulkan/graphicsPipeline.cpp
@@ -109,6 +109,13 @@ HgiVulkanGraphicsPipeline::HgiVulkanGraphicsPipeline(
             vibDivisor.divisor = _device->GetDeviceCapabilities().
                 vkVertexAttributeDivisorProperties.maxVertexAttribDivisor;
             vertBindingDivisors.push_back(std::move(vibDivisor));
+        } else if(HgiVertexBufferStepFunctionPerInstance) {
+            vib.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+
+            VkVertexInputBindingDivisorDescriptionEXT vibDivisor;
+            vibDivisor.binding = vbo.bindingIndex;
+            vibDivisor.divisor = 1;
+            vertBindingDivisors.push_back(std::move(vibDivisor));
         } else {
             vib.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
         }


### PR DESCRIPTION
### Description of Change(s)

Added missing code paths for the enum value HgiVertexBufferStepFunctionPerInstance. 
There is one commit for each of OpenGL, Vulkan, and Metal.

### Fixes Issue(s)

4043

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
