### PR TITLE
[hgi] On shader compiling errors, output ALL source with line numbers.

### DIFF
--- a/pxr/imaging/hgiGL/shaderFunction.cpp
+++ b/pxr/imaging/hgiGL/shaderFunction.cpp
@@ -12,6 +12,9 @@
 #include "pxr/imaging/hgiGL/shaderFunction.h"
 #include "pxr/imaging/hgiGL/shaderGenerator.h"
 
+#include <string>
+#include <sstream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 HgiGLShaderFunction::HgiGLShaderFunction(
@@ -44,9 +47,26 @@ HgiGLShaderFunction::HgiGLShaderFunction(
     if (status != GL_TRUE) {
         int logSize = 0;
         glGetShaderiv(_shaderId, GL_INFO_LOG_LENGTH, &logSize);
-        _errors.resize(logSize+1);
-        glGetShaderInfoLog(_shaderId, logSize, NULL, &_errors[0]);
+
+        std::string errors;
+        errors.resize(logSize+1);
+        glGetShaderInfoLog(_shaderId, logSize, NULL, &errors[0]);
         glDeleteShader(_shaderId);
+
+        _errors = "#### Source\n";
+        {
+            std::stringstream stream(shaderCode);
+            size_t indexLine = 1;
+
+            std::string line;
+            while(std::getline(stream, line)) {
+                _errors += std::to_string(indexLine) + ":" + line + "\n";
+                indexLine += 1;
+            }
+        }
+        _errors += "#### Errors\n";
+        _errors += errors;
+
         _shaderId = 0;
     }
 

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -14,6 +14,8 @@
 #include "pxr/base/tf/diagnostic.h"
 
 #include <unordered_map>
+#include <string>
+#include <sstream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -78,7 +80,19 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         _shaderId = [library newFunctionWithName:entryPoint];
         if (!_shaderId) {
             NSString *err = [error localizedDescription];
-            _errors = [err UTF8String];
+            _errors = "#### Source\n";
+            {
+                std::stringstream stream(shaderCode);
+                size_t indexLine = 1;
+
+                std::string line;
+                while(std::getline(stream, line)) {
+                    _errors += std::to_string(indexLine) + ":" + line + "\n";
+                    indexLine += 1;
+                }
+            }
+            _errors += "#### Errors\n";
+            _errors += [err UTF8String];
         }
         else {
             HGIMETAL_DEBUG_LABEL(_shaderId, _descriptor.debugName.c_str());

--- a/pxr/imaging/hgiVulkan/shaderCompiler.cpp
+++ b/pxr/imaging/hgiVulkan/shaderCompiler.cpp
@@ -14,6 +14,8 @@
 #include <shaderc/shaderc.hpp>
 
 #include <unordered_map>
+#include <string>
+#include <sstream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -75,7 +77,20 @@ HgiVulkanCompileGLSL(
         compiler.CompileGlslToSpv(source, kind, name, options);
 
     if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
-        *errors = result.GetErrorMessage();
+        *errors = std::string();
+        *errors += "#### Source\n";
+        {
+            std::stringstream stream(source);
+            size_t indexLine = 1;
+
+            std::string line;
+            while(std::getline(stream, line)) {
+                *errors += std::to_string(indexLine) + ":" + line + "\n";
+                indexLine += 1;
+            }
+        }
+        *errors += "#### Errors\n";
+        *errors += result.GetErrorMessage();
         return false;
     }
 


### PR DESCRIPTION
### Description of Change(s)

The normal hgi behaviour is to log just the reported errors. To make these errors faster to deal with, the shader compiling logs the full source, annotated with the same line numbers as the driver error messages.

This output will only be seen if there is a shader compiling error.

hgi GL, Vk, and Metal have been patched to do the same thing.

### Fixes Issue(s)

Fixes #4048

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
