### PR TITLE
Export `UsdGeomBBoxCache` destructor

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -306,6 +306,9 @@ UsdGeomBBoxCache::UsdGeomBBoxCache(UsdGeomBBoxCache const &other)
 {
 }
 
+// Default destructor
+UsdGeomBBoxCache::~UsdGeomBBoxCache() = default;
+
 UsdGeomBBoxCache &
 UsdGeomBBoxCache::operator=(UsdGeomBBoxCache const &other)
 {

--- a/pxr/usd/usdGeom/bboxCache.h
+++ b/pxr/usd/usdGeom/bboxCache.h
@@ -94,6 +94,10 @@ public:
     /// Copy constructor.
     USDGEOM_API
     UsdGeomBBoxCache(UsdGeomBBoxCache const &other);
+
+    /// Destructor
+    USDGEOM_API
+    ~UsdGeomBBoxCache();
      
     /// Copy assignment.
     USDGEOM_API


### PR DESCRIPTION
### Description of Change(s)

`UsdGeomBBoxCache`'s constructors and assignment operators are exported.  However, its destructor is not defined and  therefore not exported on Windows.  This can yield disagreement between allocation and deallocation when OpenUSD packages and downstream usage are compiled with different settings.

Exporting the destructor ensures memory is consistently managed by the `usdGeom.dll`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
