### PR TITLE
Fix C++20 operator rewriting infinite recursion in TfWeakPtrFacade

### DIFF
--- a/pxr/base/tf/weakPtrFacade.h
+++ b/pxr/base/tf/weakPtrFacade.h
@@ -107,7 +107,7 @@ public:
 
     template <class T>
     friend bool operator == (const TfRefPtr<T>& p1, Derived const &p2) {
-        return p2 == p1;
+        return p2.operator==(p1);
     }
 
     template <class T>


### PR DESCRIPTION
### Description of Change(s)

Explicitly call the member operator== using member function syntax to bypass operator lookup and potential rewriting in C++ 20. Without this change, this comparison operator produces an infinite recursion due to C++ 20's operator rewriting.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
