### PR TITLE
ARC: Fix to use correct MTLBuffer upcast type for didModifyRange call

### DIFF
--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -374,12 +374,8 @@ void HgiMetalBlitCmds::CopyBufferCpuToGpu(
         [metalBuffer->GetBufferId()
              respondsToSelector:@selector(didModifyRange:)]) {
         NSRange range = NSMakeRange(dstOffset, copyOp.byteSize);
-        id<MTLResource> resource = metalBuffer->GetBufferId();
-        
-        ARCH_PRAGMA_PUSH
-        ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
+        id<MTLBuffer> resource = metalBuffer->GetBufferId();
         [resource didModifyRange:range];
-        ARCH_PRAGMA_POP
     }
 #endif // defined(ARCH_OS_OSX)
 }


### PR DESCRIPTION
### Description of Change(s)

* `MTLBuffer` is declared as `@protocol MTLBuffer <MTLResource>`, i.e. it's a sub-protocol of `MTLResource`. So any object conforming to `MTLBuffer` also conforms to `MTLResource`. Assigning the `id<MTLBuffer>` returned by `GetBufferId()` into an `id<MTLResource>`-typed variable is a safe upcast - no warning, no cast needed.
* `id<MTLResource>` was the wrong/under-specified static type that only "worked" because the pragma was masking the compiler's complaint. `id<MTLBuffer>` is the correct, self-documenting type.

> [!NOTE]
> This is an error when compiling with Swift (v6.3.2) under C++ interop mode
> - (Swift/Clang ignores the pragma):
> >"No known instance method for selector '`didModifyRange:`'"

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
