### PR TITLE
Autodesk: Fix for lin_ciexyzd65_scene color space

### DIFF
--- a/pxr/base/gf/color.cpp
+++ b/pxr/base/gf/color.cpp
@@ -84,13 +84,31 @@ GfVec2f GfColor::_GetChromaticity() const {
     return GfVec2f(chroma.x, chroma.y);
 }
 
-// Set the color from a CIEXY coordinate in the chromaticity chart.
+// Set the color from a CIEXY coordinate in the chromaticity chart,
+// normalized such that the max RGB value is 1.0.
 // For use in testing.
 GF_API
 void GfColor::_SetFromChromaticity(const GfVec2f& xy) {
+    // Arbitrarily initialize the luminance to 1.
     NcYxy c = { 1.f, xy[0], xy[1] };
     NcRGB rgb = NcYxyToRGB(_colorSpace._data->colorSpace, c);
-    _rgb = GfVec3f(rgb.r, rgb.g, rgb.b);
+
+    // The expectation is that the max RGB of the result is 1.
+    NcRGB magRgb = {
+        fabsf(rgb.r),
+        fabsf(rgb.g),
+        fabsf(rgb.b) };
+    const float maxc = std::max({ magRgb.r, magRgb.g, magRgb.b });
+    if (maxc == 0.f) {
+        _rgb = GfVec3f(0, 0, 0);
+        return;
+    }
+    NcRGB normRgb = NcRGB {
+        rgb.r / maxc,
+        rgb.g / maxc,
+        rgb.b / maxc };
+
+    _rgb = GfVec3f(normRgb.r, normRgb.g, normRgb.b);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/gf/nc/nanocolor.c
+++ b/pxr/base/gf/nc/nanocolor.c
@@ -61,6 +61,10 @@ NCAPI const char* NcGetDescription(const NcColorSpace* cs) {
 #define _WpD65 { 0.3127f, 0.3290f }
 #define _WpACES { 0.32168f, 0.33767f }
 
+// Please note that adding color spaces to this list has implications that extend beyond
+// OpenUSD. New additions should be discussed with the ASWF Color Interop Forum to ensure
+// all projects stay in sync.
+
 static NcColorSpace _colorSpaces[] = {
     {
         // extractPrimaries(cmx %*% AP1Mx)
@@ -140,7 +144,11 @@ static NcColorSpace _colorSpaces[] = {
          1.0,
          0.0},
         0, 0,
-        { 0,0,0, 0,0,0, 0,0,0 }
+        // Define this color space using the rgbToXYZ matrix since it should be equal to
+        // the CIE XYZ connection space. The usual NPM calculation from RP 177 is not
+        // satisfactory since a D65 neutral should have an XYZ of [0.95046, 1., 1.08906]
+        // rather than [1., 1., 1].
+        { 1.,0.,0., 0.,1.,0., 0.,0.,1. }
     },
     {
         {"sRGB Encoded Rec.709 (sRGB)", "srgb_rec709_scene",
@@ -225,7 +233,9 @@ static NcColorSpace _colorSpaces[] = {
          { 0.21, 0.71 },
          { 0.15, 0.06 },
          _WpD65,
-         2.2,
+        // The specified gamma is approximately 2.199.
+        // https://en.wikipedia.org/wiki/Adobe_RGB_color_space
+         563.f / 256.f,
          0.0},
         0, 0,
         { 0,0,0, 0,0,0, 0,0,0 }
@@ -998,32 +1008,9 @@ NcYxy NcKelvinToYxy(float T, float luminance) {
     return _NcYuv2Yxy((NcYuvPrime) {luminance, u, 3.f * v / 2.f });
 }
 
-static NcYxy _NormalizeYxy(NcYxy c) {
-    return (NcYxy) {
-        c.Y,
-        c.Y * c.x / c.y,
-        c.Y * (1.f - c.x - c.y) / c.y
-    };
-}
-
-static inline float _SignOf(float x) {
-    return x > 0 ? 1.f : (x < 0) ? -1.f : 0.f;
-}
-
 NcRGB NcYxyToRGB(const NcColorSpace* cs, NcYxy c) {
-    NcYxy cYxy = _NormalizeYxy(c);
-    NcRGB rgb = NcXYZToRGB(cs, (NcXYZ) { cYxy.x, cYxy.Y, cYxy.y });
-    NcRGB magRgb = {
-        fabsf(rgb.r),
-        fabsf(rgb.g),
-        fabsf(rgb.b) };
+    NcXYZ cXYZ = NcYxyToXYZ(c);
+    NcRGB rgb = NcXYZToRGB(cs, cXYZ);
 
-    float maxc = (magRgb.r > magRgb.g) ? magRgb.r : magRgb.g;
-    maxc = maxc > magRgb.b ? maxc : magRgb.b;
-    NcRGB ret = (NcRGB) {
-        _SignOf(rgb.r) * rgb.r / maxc,
-        _SignOf(rgb.g) * rgb.g / maxc,
-        _SignOf(rgb.b) * rgb.b / maxc };
-    return ret;
+    return rgb;
 }
-

--- a/pxr/base/gf/nc/nanocolor.h
+++ b/pxr/base/gf/nc/nanocolor.h
@@ -357,7 +357,7 @@ NCAPI NcXYZ NcYxyToXYZ(NcYxy Yxy);
  *
  * @param cs The color space.
  * @param c The Yxy color coordinate.
- * @return The RGB color coordinate.
+ * @return The RGB color coordinate, with the scaling determined by Y.
  */
 NCAPI NcRGB NcYxyToRGB(const NcColorSpace* cs, NcYxy c);
 

--- a/pxr/base/gf/testenv/testGfColorCpp.cpp
+++ b/pxr/base/gf/testenv/testGfColorCpp.cpp
@@ -417,6 +417,19 @@ void testPlanckianLocus() {
     GfColor lowKelvinColor(GfColorSpace(GfColorSpaceNames->LinearRec709));
     lowKelvinColor.SetFromPlanckianLocus(999.0f, 1.0f);  // Below 1000K
     
+    // Test that the luminance argument scales output linearly.
+    {
+        GfColorSpace csLinearRec709(GfColorSpaceNames->LinearRec709);
+        GfColor c1(csLinearRec709);
+        GfColor c2(csLinearRec709);
+        GfColor cHalf(csLinearRec709);
+        c1.SetFromPlanckianLocus(6500.0f, 1.0f);
+        c2.SetFromPlanckianLocus(6500.0f, 2.0f);
+        cHalf.SetFromPlanckianLocus(6500.0f, 0.5f);
+        TF_AXIOM(GfIsClose(c2.GetRGB(), c1.GetRGB() * 2.0f, 1e-5f));
+        TF_AXIOM(GfIsClose(cHalf.GetRGB(), c1.GetRGB() * 0.5f, 1e-5f));
+    }
+
     // Should clamp to valid range and produce finite values
     GfVec3f lowKelvinRGB = lowKelvinColor.GetRGB();
     bool lowKelvinValid = !std::isnan(lowKelvinRGB[0]) && !std::isnan(lowKelvinRGB[1]) && 
@@ -646,6 +659,19 @@ void testKnownColors() {
         TF_AXIOM(GfIsClose(t7, g22_rec709_scene, 1e-5f));
         GfColor t8(t4, csG22Rec709);
         TF_AXIOM(GfIsClose(t8, g22_rec709_scene, 1e-4f));
+    }
+
+    // Test that the XYZ connection space is equal to lin_ciexyzd65_scene.
+    {
+        GfColorSpace csLinearRec709(GfColorSpaceNames->LinearRec709);
+        GfColorSpace csXYZ(GfColorSpaceNames->CIEXYZ);
+        GfColor linear_rec709_scene(GfVec3f(1.f, 1.f, 1.f), csLinearRec709);
+        GfColor whiteD65(GfVec3f(0.95045593f, 1.f, 1.08905775f), csXYZ);
+
+        GfColor t1(whiteD65, csLinearRec709);
+        TF_AXIOM(GfIsClose(t1, linear_rec709_scene, 1e-5f));
+        GfColor t2(linear_rec709_scene, csXYZ);
+        TF_AXIOM(GfIsClose(t2, whiteD65, 1e-5f));
     }
 }
 


### PR DESCRIPTION
### Description of Change(s)

Corrects the definition of the `lin_ciexyzd65_scene` color space. This color space should be equivalent to the connection space used by `NanoColor`. The value of [1.,1.,1.] in `lin_rec709_scene` when converted to `lin_ciexyzd65_scene` is currently [1.,1.,1.] but it should actually be the CIE XYZ value of D65, which is [0.95046, 1., 1.08906]. This PR adjusts the color space initialization to make that fix.

In addition, it fixes a small bug where the second argument of `SetFromPlanckianLocus` was not doing anything. As part of the fix for this, a normalization step that was in `NcYxyToRGB` was moved to `_SetFromChromaticity`. This is more in line with the way typical conversions from xyY are done, such as in `NcYxyToXYZ`.

Finally it makes a very small adjustment to correct the gamma used for the `g22_adobergb_scene` color space to match what is used in MaterialX and OpenColorIO.

Unit tests are provided.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
