### PR TITLE
Simplify transitive `imath` dependency handling

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -387,11 +387,7 @@ The additional dependencies that must be supplied when invoking cmake are:
 | Dependency Name                   | Description                                       |
 | ----------------------------------|-------------------------------------------------- |
 | ALEMBIC_DIR                       | The location of [Alembic](https://https://github.com/alembic/alembic)   | 
-| OPENEXR_LOCATION                  | The location of [OpenEXR](http://www.openexr.com) |
-| Imath_DIR (If not using OpenEXR)  | Path to the CMake package config of a Imath SDK install. (With OpenEXR 3+, Imath can be used explicitly instead of OpenEXR.)|
-
-Either OpenEXR or Imath is required depending on which library is used by the
-Alembic library specified in ALEMBIC_DIR.
+| Imath_DIR                         | Path to the CMake package config of a Imath SDK install. |
 
 See [3rd Party Library and Application Versions](VERSIONS.md) for version information.
 

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1458,9 +1458,6 @@ def InstallOpenVDB(context, force, buildArgs):
                          .format(instDir=context.instDir))
         extraArgs.append('-DTBB_ROOT="{instDir}"'
                          .format(instDir=context.instDir))
-        # OpenVDB needs Half type from IlmBase
-        extraArgs.append('-DILMBASE_ROOT="{instDir}"'
-                         .format(instDir=context.instDir))
 
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
@@ -1674,7 +1671,7 @@ PYSIDE = PythonDependency("PySide", GetPySideInstructions,
 ############################################################
 # Alembic
 
-ALEMBIC_URL = "https://github.com/alembic/alembic/archive/refs/tags/1.8.5.zip"
+ALEMBIC_URL = "https://github.com/alembic/alembic/archive/refs/tags/1.8.10.zip"
 
 def InstallAlembic(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ALEMBIC_URL, context, force)):
@@ -2643,7 +2640,7 @@ if context.buildImaging:
     requiredDependencies += [OPENSUBDIV]
 
     if context.enableOpenVDB:
-        requiredDependencies += [ZLIB, TBB, BLOSC, BOOST, OPENEXR, OPENVDB]
+        requiredDependencies += [ZLIB, TBB, BLOSC, BOOST, OPENVDB]
     
     # When OCIO is required, we need to make sure it's built before OIIO, since
     # OIIO is dependent on OCIO.

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1447,9 +1447,6 @@ def InstallOpenVDB(context, force, buildArgs):
                          .format(instDir=context.instDir))
         extraArgs.append('-DTBB_ROOT="{instDir}"'
                          .format(instDir=context.instDir))
-        # OpenVDB needs Half type from IlmBase
-        extraArgs.append('-DILMBASE_ROOT="{instDir}"'
-                         .format(instDir=context.instDir))
 
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
@@ -1656,7 +1653,7 @@ PYSIDE = PythonDependency("PySide", GetPySideInstructions,
 ############################################################
 # Alembic
 
-ALEMBIC_URL = "https://github.com/alembic/alembic/archive/refs/tags/1.8.5.zip"
+ALEMBIC_URL = "https://github.com/alembic/alembic/archive/refs/tags/1.8.10.zip"
 
 def InstallAlembic(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ALEMBIC_URL, context, force)):
@@ -2589,7 +2586,7 @@ if context.buildImaging:
     requiredDependencies += [OPENSUBDIV]
 
     if context.enableOpenVDB:
-        requiredDependencies += [ZLIB, TBB, BLOSC, BOOST, OPENEXR, OPENVDB]
+        requiredDependencies += [ZLIB, TBB, BLOSC, BOOST, OPENVDB]
     
     # When OCIO is required, we need to make sure it's built before OIIO, since
     # OIIO is dependent on OCIO.

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -261,7 +261,6 @@ if (PXR_BUILD_IMAGING)
     endif()
     # --OpenVDB
     if (PXR_ENABLE_OPENVDB_SUPPORT)
-        set(REQUIRES_Imath TRUE)
         find_package(OpenVDB REQUIRED)
         add_definitions(-DPXR_OPENVDB_SUPPORT_ENABLED)
     endif()
@@ -317,17 +316,10 @@ if(PXR_ENABLE_OSL_SUPPORT)
     add_definitions(-DPXR_OSL_SUPPORT_ENABLED)
 endif()
 
-# ----------------------------------------------
-
-# Try and find Imath or fallback to OpenEXR
-# Use ImathConfig.cmake, 
-# Refer: https://github.com/AcademySoftwareFoundation/Imath/blob/main/docs/PortingGuide2-3.md#openexrimath-3x-only
+# Try and find Imath
+# Use ImathConfig.cmake
 if(REQUIRES_Imath)
-    find_package(Imath CONFIG)
-    if (NOT Imath_FOUND)
-        MESSAGE(STATUS "Imath not found. Looking for OpenEXR instead.")
-        find_package(OpenEXR REQUIRED)
-    endif()
+    find_package(Imath CONFIG REQUIRED)
 endif()
 
 set(BUILD_SHARED_LIBS "${build_shared_libs}")

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -203,7 +203,6 @@ endif()
 if (PXR_BUILD_IMAGING)
     # --OpenImageIO
     if (PXR_BUILD_OPENIMAGEIO_PLUGIN)
-        set(REQUIRES_Imath TRUE)
         find_package(OpenImageIO REQUIRED)
         add_definitions(-DPXR_OIIO_PLUGIN_ENABLED)
         if (OIIO_idiff_BINARY)
@@ -280,7 +279,6 @@ if (PXR_BUILD_IMAGING)
     endif()
     # --OpenVDB
     if (PXR_ENABLE_OPENVDB_SUPPORT)
-        set(REQUIRES_Imath TRUE)
         find_package(OpenVDB REQUIRED)
         add_definitions(-DPXR_OPENVDB_SUPPORT_ENABLED)
     endif()
@@ -310,7 +308,6 @@ endif()
 
 if (PXR_BUILD_ALEMBIC_PLUGIN)
     find_package(Alembic REQUIRED)
-    set(REQUIRES_Imath TRUE)
     if (PXR_ENABLE_HDF5_SUPPORT)
         find_package(HDF5 REQUIRED
             COMPONENTS
@@ -331,21 +328,7 @@ endif()
 
 if(PXR_ENABLE_OSL_SUPPORT)
     find_package(OSL REQUIRED)
-    set(REQUIRES_Imath TRUE)
     add_definitions(-DPXR_OSL_SUPPORT_ENABLED)
-endif()
-
-# ----------------------------------------------
-
-# Try and find Imath or fallback to OpenEXR
-# Use ImathConfig.cmake, 
-# Refer: https://github.com/AcademySoftwareFoundation/Imath/blob/main/docs/PortingGuide2-3.md#openexrimath-3x-only
-if(REQUIRES_Imath)
-    find_package(Imath CONFIG)
-    if (NOT Imath_FOUND)
-        MESSAGE(STATUS "Imath not found. Looking for OpenEXR instead.")
-        find_package(OpenEXR REQUIRED)
-    endif()
 endif()
 
 set(BUILD_SHARED_LIBS "${build_shared_libs}")

--- a/pxr/imaging/hioOpenVDB/CMakeLists.txt
+++ b/pxr/imaging/hioOpenVDB/CMakeLists.txt
@@ -13,13 +13,6 @@ if (WIN32)
     add_definitions(-D_USE_MATH_DEFINES)
 endif()
 
-# Use the import targets set by Imath's package config
-if (Imath_FOUND)
-    LIST(APPEND __VDB_IMATH_LIBS "Imath::Imath")
-else()
-    LIST(APPEND __VDB_IMATH_LIBS ${OPENEXR_Half_LIBRARY})
-endif()
-
 pxr_library(hioOpenVDB
     LIBRARIES
         ar
@@ -27,7 +20,6 @@ pxr_library(hioOpenVDB
         hio
         tf
         usd
-        ${__VDB_IMATH_LIBS}
         ${OPENVDB_LIBRARY}
 
     INCLUDE_DIRS

--- a/pxr/imaging/plugin/hioOiio/CMakeLists.txt
+++ b/pxr/imaging/plugin/hioOiio/CMakeLists.txt
@@ -7,14 +7,6 @@ if (NOT ${PXR_BUILD_GPU_SUPPORT})
     return()
 endif()
 
-# Use the import targets set by Imath's package config
-if (Imath_FOUND)
-    set(__OIIO_IMATH_LIBS "Imath::Imath")
-else()
-    set(__OIIO_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
-    set(__OIIO_IMATH_LIBS ${OPENEXR_LIBRARIES})
-endif()
-
 pxr_plugin(hioOiio
     LIBRARIES
         ar
@@ -23,11 +15,9 @@ pxr_plugin(hioOiio
         hio
         tf
         ${OIIO_LIBRARIES}
-        ${__OIIO_IMATH_LIBS}
 
     INCLUDE_DIRS
         ${OIIO_INCLUDE_DIRS}
-        ${__OIIO_IMATH_INCLUDE}
 
     CPPFILES
         oiioImage.cpp

--- a/pxr/imaging/plugin/hioOiio/CMakeLists.txt
+++ b/pxr/imaging/plugin/hioOiio/CMakeLists.txt
@@ -7,14 +7,6 @@ if (NOT ${PXR_BUILD_GPU_SUPPORT})
     return()
 endif()
 
-# Use the import targets set by Imath's package config
-if (Imath_FOUND)
-    set(__OIIO_IMATH_LIBS "Imath::Imath")
-else()
-    set(__OIIO_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
-    set(__OIIO_IMATH_LIBS ${OPENEXR_LIBRARIES})
-endif()
-
 pxr_plugin(hioOiio
     LIBRARIES
         ar
@@ -23,11 +15,10 @@ pxr_plugin(hioOiio
         hio
         tf
         ${OIIO_LIBRARIES}
-        ${__OIIO_IMATH_LIBS}
+        Imath::Imath
 
     INCLUDE_DIRS
         ${OIIO_INCLUDE_DIRS}
-        ${__OIIO_IMATH_INCLUDE}
 
     CPPFILES
         oiioImage.cpp

--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -5,14 +5,6 @@ if(NOT PXR_ENABLE_OSL_SUPPORT)
     return()
 endif()
 
-# Use the import targets set by Imath's package config
-if (Imath_FOUND)
-    set(__OSL_IMATH_LIBS "Imath::Imath")
-else()
-    set(__OSL_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
-    set(__OSL_IMATH_LIBS ${OPENEXR_LIBRARIES})
-endif()
-
 pxr_plugin(sdrOsl
     LIBRARIES
         gf
@@ -22,12 +14,10 @@ pxr_plugin(sdrOsl
         sdr
         ${OSL_QUERY_LIBRARY}
         ${OIIO_LIBRARIES}
-        ${__OSL_IMATH_LIBS}
 
     INCLUDE_DIRS
         ${OSL_INCLUDE_DIR}
         ${OIIO_INCLUDE_DIRS}
-        ${__OSL_IMATH_INCLUDE}
 
     PUBLIC_CLASSES
         oslParser

--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -5,14 +5,6 @@ if(NOT PXR_ENABLE_OSL_SUPPORT)
     return()
 endif()
 
-# Use the import targets set by Imath's package config
-if (Imath_FOUND)
-    set(__OSL_IMATH_LIBS "Imath::Imath")
-else()
-    set(__OSL_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
-    set(__OSL_IMATH_LIBS ${OPENEXR_LIBRARIES})
-endif()
-
 pxr_plugin(sdrOsl
     LIBRARIES
         gf
@@ -22,12 +14,11 @@ pxr_plugin(sdrOsl
         sdr
         ${OSL_QUERY_LIBRARY}
         ${OIIO_LIBRARIES}
-        ${__OSL_IMATH_LIBS}
+        Imath::Imath
 
     INCLUDE_DIRS
         ${OSL_INCLUDE_DIR}
         ${OIIO_INCLUDE_DIRS}
-        ${__OSL_IMATH_INCLUDE}
 
     PRIVATE_CLASSES
         oslParser

--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -15,22 +15,6 @@ if (PXR_ENABLE_HDF5_SUPPORT)
    list(APPEND optionalIncludeDirs ${HDF5_INCLUDE_DIRS})
 endif()
 
-# Use the import targets set by Imath's package config
-# Note that the ImathConfig target must also be included to insure the
-# Imath directory is part of the include paths when compiling this
-# library. This is needed to accommodate Alembic headers that include
-# <half.h> instead of <Imath/half.h>
-if (Imath_FOUND)
-    set(__ALEMBIC_IMATH_LIBS "Imath::ImathConfig;Imath::Imath")
-else()
-    set(__ALEMBIC_IMATH_INCLUDES ${OPENEXR_INCLUDE_DIRS})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Half_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Imath_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Iex_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_IexMath_LIBRARY})
-endif()
-
-
 pxr_plugin(usdAbc
     LIBRARIES
         tf
@@ -39,12 +23,11 @@ pxr_plugin(usdAbc
         usd
         usdGeom
         ${ALEMBIC_LIBRARIES}
-        ${__ALEMBIC_IMATH_LIBS}
+        Imath::Imath
         ${optionalLibs}
 
     INCLUDE_DIRS
         ${ALEMBIC_INCLUDE_DIR}
-        ${__ALEMBIC_IMATH_INCLUDES}
         ${optionalIncludeDirs}
 
     PRIVATE_CLASSES

--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -15,22 +15,6 @@ if (PXR_ENABLE_HDF5_SUPPORT)
    list(APPEND optionalIncludeDirs ${HDF5_INCLUDE_DIRS})
 endif()
 
-# Use the import targets set by Imath's package config
-# Note that the ImathConfig target must also be included to insure the
-# Imath directory is part of the include paths when compiling this
-# library. This is needed to accommodate Alembic headers that include
-# <half.h> instead of <Imath/half.h>
-if (Imath_FOUND)
-    set(__ALEMBIC_IMATH_LIBS "Imath::ImathConfig;Imath::Imath")
-else()
-    set(__ALEMBIC_IMATH_INCLUDES ${OPENEXR_INCLUDE_DIRS})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Half_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Imath_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_Iex_LIBRARY})
-    LIST(APPEND __ALEMBIC_IMATH_LIBS ${OPENEXR_IexMath_LIBRARY})
-endif()
-
-
 pxr_plugin(usdAbc
     LIBRARIES
         tf
@@ -39,12 +23,10 @@ pxr_plugin(usdAbc
         usd
         usdGeom
         ${ALEMBIC_LIBRARIES}
-        ${__ALEMBIC_IMATH_LIBS}
         ${optionalLibs}
 
     INCLUDE_DIRS
         ${ALEMBIC_INCLUDE_DIR}
-        ${__ALEMBIC_IMATH_INCLUDES}
         ${optionalIncludeDirs}
 
     PRIVATE_CLASSES


### PR DESCRIPTION
### Description of Change(s)

This change simplifies management of `Imath` which is utilized by OSL, OpenImageIO, Alembic, and OpenEXR, all optional dependencies of OpenUSD.

`Imath` used to be a part of the `OpenEXR` project before being separated out during its `3.x` timeline.  `OpenEXR` can still provide imath as a dependency (see `OPENEXR_FORCE_INTERNAL_IMATH` used by `build_usd`).  Effort was made in the OpenUSD cmake build to be compatible with both the old OpenEXR 2.x setup and new OpenEXR 3.x setup.

Since then--
* OpenEXR 2.x hasn't been a part of the VFXPlatform since 2020.
* OpenVDB 10.x does not use `Imath` by default.  The dependency `build_usd.py` has been assuming is spurious.  Specifically, `USE_IMATH_HALF` defaults to `False`.
* Alembic 1.8.9 has been updated to include `half.h` as `imath/half.h`, avoiding the need for `ImathConfig` (https://github.com/alembic/alembic/issues/431)

To simplify the usage of `Imath` in the OpenUSD project, this PR
* Drops the OpenEXR 2.x compatibility layer
* Drops `Imath` as a dependency of `OpenVDB` (and `hioOpenVDB`) since it's not used
* Updates Alembic's patch version.

Note that `build_usd` doesn't support OSL, so that has yet to be verified

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

https://github.com/aousd/build-ig-initiatives/issues/10

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
