### PR TITLE
Remove absolute RPATHs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -615,6 +615,17 @@ There are four ways to link USD controlled by the following options:
 | PXR_BUILD_MONOLITHIC   | `OFF`     | Build single or several libraries         |
 | PXR_MONOLITHIC_IMPORT  |           | CMake file defining usd_m import library  |
 
+By default, installed binaries and plugins use origin-relative runtime paths
+to find libraries in the USD install layout. Dependencies installed elsewhere
+must be discoverable through the platform's normal library search mechanism.
+Set `CMAKE_INSTALL_RPATH_USE_LINK_PATH=ON` for compatibility with builds that
+require CMake to add external linker search directories to installed runtime
+paths. This compatibility mode may add absolute paths and make the install
+specific to the machine or dependency layout where it was built. The
+`build_usd.py` script enables this compatibility mode by default; pass
+`--no-use-link-path-rpath` to produce an install containing only the configured
+origin-relative runtime paths.
+
 ##### Shared Libraries
 
 The default creates several shared libraries.  This option allows loading

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1760,6 +1760,8 @@ def InstallUSD(context, force, buildArgs):
 
         extraArgs.append('-DPXR_PREFER_SAFETY_OVER_SPEED={}'
                          .format('ON' if context.safetyFirst else 'OFF'))
+        extraArgs.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH={}'
+                         .format('ON' if context.useLinkPathRpath else 'OFF'))
         extraArgs.append(f"-DPXR_ENABLE_COMPILER_CACHE={'ON' if context.useCompilerCache else 'OFF'}")
 
         if context.buildOneTBB:
@@ -2166,6 +2168,16 @@ subgroup.add_argument("--build-monolithic", dest="build_type",
                       help="Build a single monolithic shared library")
 
 subgroup = group.add_mutually_exclusive_group()
+subgroup.add_argument("--use-link-path-rpath", dest="use_link_path_rpath",
+                      action="store_true", default=True,
+                      help=("Add external linker search paths to installed "
+                            "runtime paths (default)"))
+subgroup.add_argument("--no-use-link-path-rpath", dest="use_link_path_rpath",
+                      action="store_false",
+                      help=("Do not add external linker search paths to "
+                            "installed runtime paths"))
+
+subgroup = group.add_mutually_exclusive_group()
 subgroup.add_argument("--tests", dest="build_tests", action="store_true",
                       default=False, help="Build unit tests")
 subgroup.add_argument("--no-tests", dest="build_tests", action="store_false",
@@ -2449,6 +2461,7 @@ class InstallContext:
         self.useCXX11ABI = \
             (args.use_cxx11_abi if hasattr(args, "use_cxx11_abi") else None)
         self.safetyFirst = args.safety_first
+        self.useLinkPathRpath = args.use_link_path_rpath
 
         # Dependencies that are forced to be built
         self.forceBuildAll = args.force_all
@@ -2829,6 +2842,7 @@ if context.useCXX11ABI is not None:
 summaryMsg += """\
     Variant                     {buildVariant}
     Target                      {buildTarget}
+    Link-path install RPATH     {useLinkPathRpath}
     UsdValidation               {buildUsdValidation}
     Imaging                     {buildImaging}
       Ptex support:             {enablePtex}
@@ -2909,6 +2923,7 @@ summaryMsg = summaryMsg.format(
                   else "Release w/ Debug Info" if context.buildRelWithDebug
                   else ""),
     buildTarget=(context.buildTarget),
+    useLinkPathRpath=("On" if context.useLinkPathRpath else "Off"),
     buildImaging=("On" if context.buildImaging else "Off"),
     enablePtex=("On" if context.enablePtex else "Off"),
     enableOpenVDB=("On" if context.enableOpenVDB else "Off"),

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -746,7 +746,6 @@ function(_pxr_install_rpath rpathRef NAME)
 
     set_target_properties(${NAME}
         PROPERTIES
-            INSTALL_RPATH_USE_LINK_PATH TRUE
             INSTALL_RPATH "${final}"
     )
 endfunction()

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -640,7 +640,7 @@ function(pxr_build_test TEST_NAME)
 
     cmake_parse_arguments(bt
         "" ""
-        "LIBRARIES;CPPFILES"
+        "LIBRARIES;CPPFILES;RPATHS"
         ${ARGN}
     )
 
@@ -664,9 +664,13 @@ function(pxr_build_test TEST_NAME)
     )
 
     # Find libraries under the install prefix, which has the core USD
-    # libraries.
+    # libraries. RPATHS handles exceptional targets, such as tests that link
+    # directly to plugins installed outside the core library directory.
     _pxr_init_rpath(rpath "tests")
     _pxr_add_rpath(rpath "${CMAKE_INSTALL_PREFIX}/lib")
+    foreach(path IN LISTS bt_RPATHS)
+        _pxr_add_rpath(rpath "${path}")
+    endforeach()
     _pxr_install_rpath(rpath ${TEST_NAME})
 
     # XXX -- We shouldn't have to install to run tests.

--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -58,6 +58,11 @@ pxr_plugin(hdEmbree
 )
 
 if (X11_FOUND OR APPLE)
+set(testHdEmbreePluginInstallDir "plugin/usd")
+if(PXR_INSTALL_SUBDIR)
+    set(testHdEmbreePluginInstallDir "${PXR_INSTALL_SUBDIR}/plugin")
+endif()
+
 pxr_build_test(testHdEmbree
     LIBRARIES
         arch
@@ -68,5 +73,7 @@ pxr_build_test(testHdEmbree
         hio
     CPPFILES
         testenv/testHdEmbree.cpp
+    RPATHS
+        "${CMAKE_INSTALL_PREFIX}/${testHdEmbreePluginInstallDir}"
 )
 endif()

--- a/third_party/renderman/plugin/hdPrman/CMakeLists.txt
+++ b/third_party/renderman/plugin/hdPrman/CMakeLists.txt
@@ -252,6 +252,11 @@ if(WIN32 AND NOT BUILD_SHARED_LIBS)
     # XXX: Temporarily disable this test on static Windows builds
     #      due to symbol visibility issues.
 else()
+    set(testHdPrmanPluginInstallDir "plugin/usd")
+    if(PXR_INSTALL_SUBDIR)
+        set(testHdPrmanPluginInstallDir "${PXR_INSTALL_SUBDIR}/plugin")
+    endif()
+
     pxr_build_test(testHdPrman
         LIBRARIES
             cameraUtil
@@ -264,5 +269,7 @@ else()
             ${PRMAN_LIBRARY}
         CPPFILES
             testenv/testHdPrman.cpp
+        RPATHS
+            "${CMAKE_INSTALL_PREFIX}/${testHdPrmanPluginInstallDir}"
     )
 endif()


### PR DESCRIPTION
### Description of Change(s)

Removes absolute RPATHs from libraries. The first RPATH entries are already valid $ORIGIN relative paths, so the non-relocatable absolute paths are not necessary.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
