### PR TITLE
Prevent writing empty customData items

### DIFF
--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -345,6 +345,14 @@ pxr_build_test(testSdfLayerHints
         testenv/testSdfLayerHints.cpp
 )
 
+pxr_build_test(testSdfInvalidDictionaryAuthoring
+    LIBRARIES
+        sdf
+        tf
+    CPPFILES
+        testenv/testSdfInvalidDictionaryAuthoring.cpp
+)
+
 pxr_build_test(testSdfMetaDataPlugInfo
     LIBRARIES
         sdf
@@ -575,6 +583,10 @@ pxr_register_test(testSdfLayerHints
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerHints"
     TESTENV testenv/testSdfLayerHints.testenv
     TESTENV_DEST testSdfLayerHints/testSdfLayerHints.testenv
+)
+
+pxr_register_test(testSdfInvalidDictionaryAuthoring
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfInvalidDictionaryAuthoring"
 )
 
 pxr_register_test(testSdfLayerMuting

--- a/pxr/usd/sdf/fileIO_Common.cpp
+++ b/pxr/usd/sdf/fileIO_Common.cpp
@@ -841,6 +841,18 @@ Sdf_FileIOUtility::_WriteDictionary(
     Sdf_FileIOUtility::_OrderedDictionary &dictionary,
     bool stringValuesOnly)
 {
+    for (auto it = dictionary.begin(); it != dictionary.end(); ) {
+        if (it->second->IsEmpty()) {
+            TF_CODING_ERROR(
+                "Skipping dictionary entry '%s' because its value is empty",
+                it->first->c_str());
+            it = dictionary.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+
     Puts(out, 0, multiLine ? "{\n" : "{ ");
     size_t counter = dictionary.size();
     TF_FOR_ALL(i, dictionary) {

--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -1991,7 +1991,14 @@ SdfLayer::GetCustomLayerData() const
 void
 SdfLayer::SetCustomLayerData(const VtDictionary& dict)
 {
-    _SetValue(SdfFieldKeys->CustomLayerData, dict);
+    VtDictionary validated = dict;
+    std::string errorMessage;
+    if (!SdfConvertToValidMetadataDictionary(&validated, &errorMessage)) {
+        TF_CODING_ERROR(
+            "Cannot set customLayerData: %s", errorMessage.c_str());
+        return;
+    }
+    _SetValue(SdfFieldKeys->CustomLayerData, std::move(validated));
 }
 
 bool 

--- a/pxr/usd/sdf/testenv/testSdfInvalidDictionaryAuthoring.cpp
+++ b/pxr/usd/sdf/testenv/testSdfInvalidDictionaryAuthoring.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright 2026 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/pxr.h"
+
+#include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/errorMark.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/vt/dictionary.h"
+#include "pxr/usd/sdf/layer.h"
+#include "pxr/usd/sdf/schema.h"
+#include "pxr/usd/sdf/types.h"
+
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static VtDictionary
+_GetInvalidDictionary()
+{
+    return {
+        {"invalid", VtValue()},
+        {"valid", VtValue(std::string("value"))}
+    };
+}
+
+static void
+_VerifyDictionaryConversionRejectsEmptyValues()
+{
+    VtDictionary dictionary = _GetInvalidDictionary();
+    std::string errorMessage;
+    TF_AXIOM(
+        !SdfConvertToValidMetadataDictionary(&dictionary, &errorMessage));
+    TF_AXIOM(TfStringContains(
+        errorMessage,
+        "empty value under key 'invalid' is not a valid dictionary entry"));
+}
+
+static void
+_VerifyAuthoringRejectsEmptyValues()
+{
+    const VtDictionary invalidDictionary = _GetInvalidDictionary();
+
+    SdfLayerRefPtr layer = SdfLayer::CreateAnonymous(".usda");
+    TfErrorMark mark;
+    layer->SetCustomLayerData(invalidDictionary);
+    TF_AXIOM(!mark.IsClean());
+    mark.Clear();
+    TF_AXIOM(layer->GetCustomLayerData().empty());
+}
+
+static void
+_VerifyWriterSkipsEmptyValues()
+{
+    SdfLayerRefPtr layer = SdfLayer::CreateAnonymous(".usda");
+
+    // Use the raw field API to bypass the validated dictionary setters and
+    // verify that the writer still cannot emit a typeless dictionary entry.
+    layer->SetField(
+        SdfPath::AbsoluteRootPath(),
+        SdfFieldKeys->CustomLayerData,
+        VtValue(_GetInvalidDictionary()));
+
+    std::string layerText;
+    TfErrorMark mark;
+    TF_AXIOM(layer->ExportToString(&layerText));
+    TF_AXIOM(!mark.IsClean());
+    mark.Clear();
+
+    TF_AXIOM(!TfStringContains(layerText, "invalid ="));
+    TF_AXIOM(TfStringContains(layerText, "string valid = \"value\""));
+}
+
+int
+main()
+{
+    _VerifyDictionaryConversionRejectsEmptyValues();
+    _VerifyAuthoringRejectsEmptyValues();
+    _VerifyWriterSkipsEmptyValues();
+}

--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -796,7 +796,14 @@ _ConvertToValidMetadataDictValueInternal(
 
     bool allValid = true;
 
-    if (value->IsHolding<VtDictionary>()) {
+    if (value->IsEmpty()) {
+        errMsgs->push_back(
+            TfStringPrintf(
+                "empty value%s is not a valid dictionary entry",
+                _GetKeyPathText(*keyPath).c_str()));
+        allValid = false;
+    }
+    else if (value->IsHolding<VtDictionary>()) {
         VtDictionary d;
         value->UncheckedSwap(d);
         for (auto &kv: d) {


### PR DESCRIPTION
### Description of Change(s)

Prevents writing customData/customLayerData dictionary items that do not have values. Currently, python dictionaries with `None` values become empty VtValues and result in this:
```python
layer.customLayerData = {
    "malformed_kvp":  None,
}

```
```
customData = {
    malformed_kvp=
}
```

This PR validates in `SdfConvertToValidMetadataDictionary` and `SdfLayer::SetCustomLayerData`, and has a usda writer safeguard. `SdfMapEditProxy::operator[]` temporarily inserts empty VtValues, a schema map level validator looked like it would be much more invasive, so I have omitted that in this PR but could add/make another for it if desired.

### Fixes Issue(s)
USD will no longer write USDA files that error during parsing and cannot be loaded.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
