### PR TITLE
Autodesk: Fix prototype naming repeatability

### DIFF
--- a/pxr/usd/usd/instanceCache.cpp
+++ b/pxr/usd/usd/instanceCache.cpp
@@ -149,6 +149,18 @@ Usd_InstanceCache::ProcessChanges(Usd_InstanceChanges* changes)
         // determines the name of the prototype prims assigned to instances.
         // We need to iterate over the hash map in a fixed ordering to
         // ensure we have a consistent assignment of instances to prototypes.
+        //
+        // We order the keys by the minimum prim index path registered for
+        // each key. Using the minimum (rather than the arbitrary first-
+        // registered index, which depends on non-deterministic multithreaded
+        // composition order) gives a repeatable ordering for a fixed set of
+        // instances. It is also robust for nested instancing: a nested key's
+        // prim indexes are always descendants of the prim index that was
+        // selected as the source of the enclosing prototype, so the enclosing
+        // prototype's minimum path always sorts before the nested prototype's
+        // minimum path. This guarantees enclosing prototypes are numbered
+        // before the prototypes nested within them, regardless of which
+        // instance was composed as the enclosing prototype's source.
         typedef std::map<SdfPath, Usd_InstanceKey> _PrimIndexPathToKey;
         std::map<SdfPath, Usd_InstanceKey> keysToProcess;
         for (_InstanceKeyToPrimIndexesMap::value_type& v:
@@ -156,8 +168,9 @@ Usd_InstanceCache::ProcessChanges(Usd_InstanceChanges* changes)
             const Usd_InstanceKey& key = v.first;
             const _PrimIndexPaths& primIndexes = v.second;
             if (TF_VERIFY(!primIndexes.empty())) {
-                TF_VERIFY(
-                    keysToProcess.emplace(primIndexes.front(), key).second);
+                const SdfPath& selectedPrimIndex = *std::min_element(
+                    primIndexes.begin(), primIndexes.end());
+                TF_VERIFY(keysToProcess.emplace(selectedPrimIndex, key).second);
             }
         }
 


### PR DESCRIPTION
### Description of Change(s)

Fixes [PixarAnimationStudios/OpenUSD#2431](https://github.com/PixarAnimationStudios/OpenUSD/issues/2431) — `USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY` fails to guarantee consistent prototype naming across application runs.

When `USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY=1` is set, prototype names should be identical across executions to enable reproducible workflows, version control diffing, and automated pipelines. However, `stage->GetPrototypes()` returns different prototype paths between runs of the same scene.

The root cause is in `Usd_InstanceCache::ProcessChanges()`: when selecting a representative prim index path per instance key, the code used `primIndexes.front()`. Because `_PrimIndexPaths` iteration order is non-deterministic (hash map), different runs select different representatives, causing prototype names to vary.

Replace `primIndexes.front()` with a deterministic selection: iterate all prim index paths for a key and choose the lexicographically greatest `SdfPath`. This guarantees the same representative is chosen regardless of container ordering.

References: [AOUSD Forum Discussion](https://forum.aousd.org/t/scenegraph-instancing-importing/2770/2)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/2431

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
