### PR TITLE
Autodesk: GfColorSpace must always initialize transfer function parameters

### DIFF
--- a/pxr/base/gf/nc/nanocolor.c
+++ b/pxr/base/gf/nc/nanocolor.c
@@ -338,12 +338,15 @@ static NcM33f _M33fMultiply(NcM33f lh, NcM33f rh) {
 }
 
 static void _InitColorSpace(NcColorSpace* cs) {
-    if (!cs || cs->rgbToXYZ.m[8] != 0.0)
+    if (!cs)
         return;
 
     const float a = cs->desc.linearBias;
     const float gamma = cs->desc.gamma;
 
+    // Always initialise K0 and phi from the transfer function parameters.
+    // These are needed by _ToLinear/_FromLinear regardless of whether the
+    // color space was constructed from chromaticities or a matrix directly.
     if (gamma == 1.f) {
         cs->K0 = 1.e9f;
         cs->phi = 1.f;
@@ -361,6 +364,14 @@ static void _InitColorSpace(NcColorSpace* cs) {
                        (gamma - 1.f);
         }
     }
+
+    // If the matrix is already set, skip the chromaticity-to-matrix
+    // computation below. This handles two cases:
+    //   1. NcCreateColorSpaceM33: matrix supplied directly by the caller.
+    //   2. Re-initialisation guard: built-in spaces whose matrix has already
+    //      been computed by a prior _InitColorSpace call.
+    if (cs->rgbToXYZ.m[8] != 0.0)
+        return;
 
     // if the primaries are zero, the color space was defined by the 3x3 matrix,
     if (cs->desc.whitePoint.x == 0.f)

--- a/pxr/base/gf/testenv/testGfColorCpp.cpp
+++ b/pxr/base/gf/testenv/testGfColorCpp.cpp
@@ -358,7 +358,7 @@ void testColorSpace() {
     TF_AXIOM(customSpace.GetLinearBias() == linearBias);
 
     auto transferParams = customSpace.GetTransferFunctionParams();
-    bool transferParamsExist = (transferParams.first != 0.0f || transferParams.second != 0.0f);
+    bool transferParamsExist = (transferParams.first != 0.0f && transferParams.second != 0.0f);
     TF_AXIOM(transferParamsExist);
 
     // Define a custom RGB to XYZ matrix (Rec.709 matrix)
@@ -376,6 +376,19 @@ void testColorSpace() {
     TF_AXIOM(GfIsClose(returnedMatrix, rgbToXYZ, 1e-5f));
     TF_AXIOM(GfIsClose(matrixSpace.GetGamma(), gamma, 1e-6f));
     TF_AXIOM(GfIsClose(matrixSpace.GetLinearBias(), linearBias, 1e-6f));
+
+    // Check that the K0 and Phi have been initialized
+    auto matrixTransferParams = matrixSpace.GetTransferFunctionParams();
+    bool matrixTransferParamsExist = (matrixTransferParams.first != 0.0f && matrixTransferParams.second != 0.0f);
+    TF_AXIOM(matrixTransferParamsExist);
+
+    // Exercise the gamma == 1.0 branch of the transfer function initialization
+    // for a color space defined directly by a matrix.
+    TfToken linearMatrixSpaceName("linear_matrix_space");
+    GfColorSpace linearMatrixSpace(linearMatrixSpaceName, rgbToXYZ, 1.0f, 0.0f);
+    auto linearTransferParams = linearMatrixSpace.GetTransferFunctionParams();
+    bool linearTransferParamsExist = (linearTransferParams.first != 0.0f && linearTransferParams.second != 0.0f);
+    TF_AXIOM(linearTransferParamsExist);
 }
 
 void testPlanckianLocus() {


### PR DESCRIPTION
### Description of Change(s)

Modified the GfColorSpace initialization code in nanocolor.c, so that it always initializes the transfer function parameters K0 and phi.

Added unit test coverage to testGfColorCpp.cpp.

Details: 
Currently, if a GfColorSpace is created using a 3x3 matrix rather than chromaticity coordinates, K0 and phi are not initialized to their correct values. Leaving them both at 0. will generate either Inf or NaN in the _FromLinear or _ToLinear functions when evaluating the resulting color space.

In addition, there is a more subtle bug when using the UsdColorSpaceDefinitionAPI and CreateColorSpaceAttrsWithMatrix to create color spaces that use the sRGB transfer function. Because the test for the linear segment in _ToLinear results in NaN, that branch is never taken, and only the power function is used. This results in the chromaticity coordinates extracted from the 3x3 matrix having small errors. If ComputeColorSpaceFromDefinitionAttributes is then called to get the color space and GetRGBToXYZ is used to extract the regenerated 3x3 matrix, it no longer matches the original matrix used to initialize the color space definition.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
