### PR TITLE
Autodesk: [HdSt] Fix OOB shader access for basis curves inData

### DIFF
--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -97,7 +97,7 @@ CurveData PopulatePeyeAndNeye()
 CurveData PopulatePeyeAndNeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
         vertexData.Neye[i] = inData[i].Neye;
     }
@@ -110,7 +110,7 @@ CurveData PopulatePeyeAndNeye()
 CurveData PopulatePeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
     }
     return vertexData;

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_curves_indirect.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_curves_indirect.out
@@ -1498,7 +1498,7 @@ float GetScreenSpaceWidth(int index, CurveData vertexData, MAT4 projMat)
 CurveData PopulatePeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
     }
     return vertexData;
@@ -2242,7 +2242,7 @@ bool IsFlipped()
 CurveData PopulatePeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
     }
     return vertexData;

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_curves_indirect.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_curves_indirect.out
@@ -1490,7 +1490,7 @@ float GetScreenSpaceWidth(int index, CurveData vertexData, MAT4 projMat)
 CurveData PopulatePeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
     }
     return vertexData;
@@ -2229,7 +2229,7 @@ bool IsFlipped()
 CurveData PopulatePeye()
 {
     CurveData vertexData;
-    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+    for (int i = 0; i < 4; i++) {
         vertexData.Peye[i] = inData[i].Peye;
     }
     return vertexData;


### PR DESCRIPTION
### Description of Change(s)
The `CurveData` arrays have a hardcoded size of 4, so don't write more than 4 values.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
