### PR TITLE
Remove duplicate `plugInfo.json` entry in `usdMtlx`

### DIFF
--- a/pxr/usd/usdMtlx/CMakeLists.txt
+++ b/pxr/usd/usdMtlx/CMakeLists.txt
@@ -80,7 +80,6 @@ pxr_library(usdMtlx
         __init__.py
 
     RESOURCE_FILES
-        plugInfo.json
         ${MATERIALX_STDLIB_RESOURCES}
 
     DOXYGEN_FILES


### PR DESCRIPTION
### Description of Change(s)

4c880b53eb88b9f882a4aab0f86427e8325aa228 introduced schemas into `usdMtlx`.  This shifted the `plugInfo.json` declaration into the `generatedSchema.classes.txt` and removed the `RESOURCE_FILES` section completely

https://github.com/PixarAnimationStudios/OpenUSD/blob/c32a44659e16a8a3c132d3205dd5c439317f6aee/pxr/usd/usdMtlx/generatedSchema.classes.txt#L14

983e2d9601323bbe6634610266af28c056617cae reintroduced `RESOURCE_FILES` with a duplicate `plugInfo.json` declaration.

https://github.com/PixarAnimationStudios/OpenUSD/blob/c32a44659e16a8a3c132d3205dd5c439317f6aee/pxr/usd/usdMtlx/CMakeLists.txt#L83

This was detected while evaluating #1983 for https://github.com/aousd/build-ig-initiatives/issues/36. #1983 is more sensitive to duplicate entries.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
