### PR TITLE
Autodesk: Fix HdDependencyForwardingSceneIndex::_PrimsRemoved

### DIFF
--- a/pxr/imaging/hd/dependencyForwardingSceneIndex.cpp
+++ b/pxr/imaging/hd/dependencyForwardingSceneIndex.cpp
@@ -8,6 +8,7 @@
 #include "pxr/imaging/hd/dependenciesSchema.h"
 #include "pxr/imaging/hd/retainedDataSource.h"
 #include "pxr/imaging/hd/overlayContainerDataSource.h"
+#include "pxr/base/tf/hashset.h"
 #include "pxr/base/trace/trace.h"
 #include "pxr/base/work/loops.h"
 #include "pxr/base/work/utils.h"
@@ -188,9 +189,34 @@ HdDependencyForwardingSceneIndex::_PrimsRemoved(
     _AdditionalDirtiedVector additionalDirtied;
     _PathSet rebuildDependencies;
 
+    // Create a hashset of entries
+    TfHashSet<SdfPath, SdfPath::Hash> removedEntriesHashSet;
+    removedEntriesHashSet.reserve(entries.size());
+    for (const HdSceneIndexObserver::RemovedPrimEntry& entry : entries) {
+        removedEntriesHashSet.insert(entry.primPath);
+    }
+
+    // Function to quickly check if a prim (including any parent prim) has been removed.
+    // (When a parent prim is removed, all child prims are also removed).
+    auto hasBeenRemoved = [&removedEntriesHashSet](const SdfPath& primToCheck)
+    {
+        // Check if the prim has been removed, or if a parent of the prim
+        for (SdfPath path = primToCheck; !path.IsEmpty(); path = path.GetParentPath())
+        {
+            if (removedEntriesHashSet.find(path) != removedEntriesHashSet.end())
+            {
+                return true;
+            }
+            if (path.IsAbsoluteRootPath())
+            {
+                break;
+            }
+        }
+        return false;
+    };
+
     // Because of the recursive nature of remove notices, we need to iterate the
-    // whole dependency map, which is (hopefully) bigger than the notice vector,
-    // so we iterate the map as the outer loop.
+    // whole dependency map.
     //
     // Iterate _affectedPrimToDependsOnPathsMap looking for:
     // - Affected prims that are descendants of primPath.
@@ -199,15 +225,9 @@ HdDependencyForwardingSceneIndex::_PrimsRemoved(
     [&](const _AffectedPrimToDependsOnPathsEntryMap::range_type& range) {
     for (auto it = range.begin(); it != range.end(); ++it) {
         _AffectedPrimToDependsOnPathsEntryMap::value_type& pair = *it;
-        for (const HdSceneIndexObserver::RemovedPrimEntry &entry : entries) {
-            // Note: if this loop becomes a bottleneck, we could sort
-            // entries by path and do a binary search to slightly bend the
-            // O(n) time, but on current scenes it doesn't seem worth it.
-            if (pair.first.HasPrefix(entry.primPath)) {
-                pair.second.flaggedForDeletion = true;
-                _potentiallyDeletedAffectedPaths.insert(pair.first);
-                break;
-            }
+        if (hasBeenRemoved(pair.first)) {
+            pair.second.flaggedForDeletion = true;
+            _potentiallyDeletedAffectedPaths.insert(pair.first);
         }
     }});
 
@@ -233,50 +253,55 @@ HdDependencyForwardingSceneIndex::_PrimsRemoved(
         _DependedOnPrimsAffectedPrimsMap::value_type& depPair = *it;
         WorkParallelForTBBRange(depPair.second.range(),
         [&](const _AffectedPrimsDependencyMap::range_type& range) {
+
+        // Note: these are scoped to the parallel range (rather than the whole
+        // depPair) so that they stay thread-local; depPair.first is constant
+        // across the inner loop, so caching within the range is still a win.
+        bool dependedOnChecked = false;
+        bool dependedOnRemoved = false;
+
         for (auto it = range.begin(); it != range.end(); ++it) {
             _AffectedPrimsDependencyMap::value_type& affPair = *it;
 
-            for (const HdSceneIndexObserver::RemovedPrimEntry &entry :
-                    entries) {
-                // Note: if this loop becomes a bottleneck, we could sort
-                // entries by path and do a binary search to slightly bend the
-                // O(n) time, but on current scenes it doesn't seem worth it.
-
-                // If the affected prim was deleted, mark the
-                // dependedOnPrim->affectedPrim entry for deletion.
-                if (affPair.first.HasPrefix(entry.primPath)) {
-                    affPair.second.flaggedForDeletion = true;
-                    _potentiallyDeletedDependedOnPaths.insert(depPair.first);
-                    break;
-                }
+            if (hasBeenRemoved(affPair.first))
+            {
+                affPair.second.flaggedForDeletion = true;
+                _potentiallyDeletedDependedOnPaths.insert(depPair.first);
             }
 
+            // We keep this condition separate, in case this has already been flagged for deletion
+            // from elsewhere.
             if (affPair.second.flaggedForDeletion) {
                 continue;
             }
 
+            // Only check ONCE per TBB range if the "depended on" was removed.
+            // This is either true or false for all items in the inner loop.
+            // Note: This could be moved out of the inner loop for the sake 
+            // of simplicity, but it likely is more optimal to do it here,
+            // after the early out, in case this code is not even reached.
+            if (!dependedOnChecked)
+            {
+                dependedOnRemoved = hasBeenRemoved(depPair.first);
+                dependedOnChecked = true;
+            }
+
             // Otherwise, if the affected prim remains but the depended on
             // prim was deleted, send dirty notices.
-            for (const HdSceneIndexObserver::RemovedPrimEntry &entry :
-                    entries) {
-                // Note: if this loop becomes a bottleneck, we could sort
-                // entries by path and do a binary search to slightly bend the
-                // O(n) time, but on current scenes it doesn't seem worth it.
-                if (depPair.first.HasPrefix(entry.primPath)) {
-                    HdDataSourceLocatorSet affectedLocators;
-                    for (const auto &keyEntryPair :
-                            affPair.second.locatorsEntryMap) {
-                        const _LocatorsEntry &entry = keyEntryPair.second;
-                        affectedLocators.insert(
-                            entry.affectedDataSourceLocator);
-                    }
+            if (dependedOnRemoved) {
+                HdDataSourceLocatorSet affectedLocators;
+                for (const auto &keyEntryPair :
+                        affPair.second.locatorsEntryMap) {
+                    const _LocatorsEntry &entry = keyEntryPair.second;
+                    affectedLocators.insert(
+                        entry.affectedDataSourceLocator);
+                }
 
-                    if (!affectedLocators.IsEmpty()) {
-                        additionalDirtied.emplace_back(affPair.first,
-                            affectedLocators);
-                        _PrimDirtied(affPair.first, affectedLocators,
-                            &visited, &additionalDirtied, &rebuildDependencies);
-                    }
+                if (!affectedLocators.IsEmpty()) {
+                    additionalDirtied.emplace_back(affPair.first,
+                        affectedLocators);
+                    _PrimDirtied(affPair.first, affectedLocators,
+                        &visited, &additionalDirtied, &rebuildDependencies);
                 }
             }
         }});


### PR DESCRIPTION
### Description of Change(s)

Improve performance of [HdDependencyForwardingSceneIndex::_PrimsRemoved](https://github.com/PixarAnimationStudios/OpenUSD/blob/c32a44659e16a8a3c132d3205dd5c439317f6aee/pxr/imaging/hd/dependencyForwardingSceneIndex.cpp#L171-L306) with large number of removed prims. For use cases where `entries` input has thousands of prims, avoid the inner loop and use a SdfPath HashSet instead.

The previous logic based on `SdfPath::HasPrefix(SdfPath other)`, which would return true if `other` is either equal or a parent of the SdfPath was replaced with the use of a new local function `hasBeenRemoved(const& SdfPath path)` which walks up through the parents of `path` (including /) and returns true on the first hashset hit.

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/4157

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))

