### PR TITLE
usdPhysics: exclude disabled colliders from mass computation

### DIFF
--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -43,7 +43,10 @@ class SdfAssetPath;
 /// physics:rigidBodyEnabled is false, takes no part in simulation, so any
 /// MassAPI applied to it is likewise ignored. When neither an enabled
 /// collider nor an enabled rigid body remains on a prim, it is not a physics
-/// prim and its MassAPI has no effect.
+/// prim and its MassAPI has no effect. Note that this concerns only the prim
+/// the MassAPI is applied to: disabling a prim does not discard the mass of
+/// the enabled colliders beneath it, which continue to contribute to the
+/// nearest enabled rigid body above them.
 ///
 class UsdPhysicsMassAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -37,7 +37,13 @@ class SdfAssetPath;
 ///
 /// Defines explicit mass properties (mass, density, inertia etc.).        
 /// MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-/// a PhysicsRigidBodyAPI.
+/// a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
+/// PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
+/// physics:collisionEnabled is false, or a rigid body whose
+/// physics:rigidBodyEnabled is false, takes no part in simulation, so any
+/// MassAPI applied to it is likewise ignored. When neither an enabled
+/// collider nor an enabled rigid body remains on a prim, it is not a physics
+/// prim and its MassAPI has no effect.
 ///
 class UsdPhysicsMassAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -313,7 +313,11 @@ a prim higher in the tree, overrides any density specified via a material
 times the locally effective density.
 
 \li Implicit mass of a rigid body is the total implicit mass of all children in
-the subtree belonging to the rigid body.
+the subtree belonging to the rigid body. Only enabled colliders are counted
+among these children: a collider whose physics:collisionEnabled is false, or a
+child rigid body whose physics:rigidBodyEnabled is false, takes no part in
+simulation and is excluded from the mass computation, so any UsdPhysicsMassAPI
+applied to it has no effect.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -226,6 +226,12 @@ of a rigid body that are not parts of other rigid bodies. Multiple rigid bodies
 in a subtree move completely independently, even if their transforms are stored
 relative to one another.  
 
+This exception applies only while the nested UsdPhysicsRigidBodyAPI is enabled.
+A nested rigid body whose physics:rigidBodyEnabled is false takes no part in
+simulation and therefore does not create a separate rigid body, so it does not
+form the root of its own subtree; the prims below it remain part of the nearest
+enabled rigid body above it in the hierarchy.
+
 If aggregate properties of the entire rigid body must be computed, such as
 total mass or the entirety of its collision volume, then the contents of the
 entire subtree are considered, taking care to exclude the contents of any
@@ -314,10 +320,14 @@ times the locally effective density.
 
 \li Implicit mass of a rigid body is the total implicit mass of all children in
 the subtree belonging to the rigid body. Only enabled colliders are counted
-among these children: a collider whose physics:collisionEnabled is false, or a
-child rigid body whose physics:rigidBodyEnabled is false, takes no part in
-simulation and is excluded from the mass computation, so any UsdPhysicsMassAPI
-applied to it has no effect.
+among these children: a collider whose physics:collisionEnabled is false takes
+no part in simulation and is excluded from the mass computation, so any
+UsdPhysicsMassAPI applied to it has no effect. Likewise, a UsdPhysicsMassAPI
+applied to a nested rigid body whose physics:rigidBodyEnabled is false has no
+effect. Note however that a disabled nested rigid body does not itself form the
+root of a subtree: because it takes no part in simulation it owns no colliders,
+so the enabled colliders below it still belong to the nearest enabled rigid body
+above it and still contribute their mass to it.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -1635,6 +1635,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
 {
     bool physicsAPIFound = false;
     UsdPrim parent = usdPrim;
+    UsdPrim disabledBodyPrim = UsdPrim();
     while (parent != usdPrim.GetStage()->GetPseudoRoot())
     {
         if (_IsDynamicBody(parent, bodyMap, &physicsAPIFound))
@@ -1645,11 +1646,26 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
 
         if (physicsAPIFound)
         {
-            *outBodyPrimPath = parent;
-            return false;
+            // A disabled rigid body takes no part in simulation, so it does
+            // not own this prim. Keep searching the ancestors: a nested
+            // disabled body may still have an enabled body above it, which
+            // this prim belongs to. Remember the nearest disabled body so it
+            // can still be reported if no enabled body is found at all.
+            if (disabledBodyPrim == UsdPrim())
+            {
+                disabledBodyPrim = parent;
+            }
         }
 
         parent = parent.GetParent();
+    }
+
+    // No enabled body above this prim. Report the nearest disabled body, if
+    // any, so it is still recognized as belonging to a body that is present
+    // but not simulating rather than as a static collision.
+    if (disabledBodyPrim != UsdPrim())
+    {
+        *outBodyPrimPath = disabledBodyPrim;
     }
     return false;
 }

--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -498,6 +498,14 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
 
             if (collisionPrim && collisionPrim.HasAPI<UsdPhysicsCollisionAPI>())
             {
+                const UsdPhysicsCollisionAPI collisionAPI(collisionPrim);
+                bool collisionEnabled = true;
+                collisionAPI.GetCollisionEnabledAttr().Get(&collisionEnabled);
+                if (!collisionEnabled)
+                {
+                    continue;
+                }
+
                 collisionPrims.push_back(std::move(collisionPrim));
             }
         }

--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -490,10 +490,21 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
             if (collisionPrim && collisionPrim != usdPrim && 
                 collisionPrim.HasAPI<UsdPhysicsRigidBodyAPI>())
             {
-                it.PruneChildren(); // Skip the subtree rooted at this prim, 
-                                    // the colliders belong to a different rigid 
-                                    // body
-                continue;
+                // A nested rigid body only forms the root of its own subtree
+                // while it is enabled. A disabled body takes no part in 
+                // simulation, so it does not own colliders; its subtree still 
+                // belongs to this body and must be traversed, otherwise the 
+                // colliders below it would contribute mass to no body at all.
+                const UsdPhysicsRigidBodyAPI nestedBodyAPI(collisionPrim);
+                bool nestedBodyEnabled = true;
+                nestedBodyAPI.GetRigidBodyEnabledAttr().Get(&nestedBodyEnabled);
+                if (nestedBodyEnabled)
+                {
+                    it.PruneChildren(); // Skip the subtree rooted at this prim, 
+                                        // the colliders belong to a different 
+                                        // rigid body
+                    continue;
+                }
             }
 
             if (collisionPrim && collisionPrim.HasAPI<UsdPhysicsCollisionAPI>())

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -208,7 +208,10 @@ class "PhysicsMassAPI"
     physics:rigidBodyEnabled is false, takes no part in simulation, so any
     MassAPI applied to it is likewise ignored. When neither an enabled
     collider nor an enabled rigid body remains on a prim, it is not a physics
-    prim and its MassAPI has no effect."""
+    prim and its MassAPI has no effect. Note that this concerns only the prim
+    the MassAPI is applied to: disabling a prim does not discard the mass of
+    the enabled colliders beneath it, which continue to contribute to the
+    nearest enabled rigid body above them."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -202,7 +202,13 @@ class "PhysicsMassAPI"
 
     doc = """Defines explicit mass properties (mass, density, inertia etc.).        
     MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-    a PhysicsRigidBodyAPI."""
+    a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
+    PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
+    physics:collisionEnabled is false, or a rigid body whose
+    physics:rigidBodyEnabled is false, takes no part in simulation, so any
+    MassAPI applied to it is likewise ignored. When neither an enabled
+    collider nor an enabled rigid body remains on a prim, it is not a physics
+    prim and its MassAPI has no effect."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -512,6 +512,59 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
+    def test_rigidbody_disabled_nested_body_collision_parse(self):
+        """A nested rigid body only owns colliders while it is enabled. A
+        collider below a disabled nested body must be reported as belonging to
+        the nearest enabled rigid body above it, matching the subtree that
+        UsdPhysicsRigidBodyAPI::ComputeMassProperties aggregates.
+        """
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        rigidbody = UsdGeom.Xform.Define(stage, "/rigidBody")
+        UsdPhysics.RigidBodyAPI.Apply(rigidbody.GetPrim())
+
+        # Disabled nested rigid body: it takes no part in simulation, so it
+        # does not form the root of its own subtree.
+        disabled_body = UsdGeom.Xform.Define(stage, "/rigidBody/disabledBody")
+        disabled_body_api = UsdPhysics.RigidBodyAPI.Apply(
+            disabled_body.GetPrim())
+        disabled_body_api.GetRigidBodyEnabledAttr().Set(False)
+
+        cube = UsdGeom.Cube.Define(stage, "/rigidBody/disabledBody/cube")
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+        ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(stage, ["/"])
+
+        rigidbody_found = False
+        cube_found = False
+
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.RigidBody:
+                for prim_path, desc in zip(prim_paths, descs):
+                    if prim_path == rigidbody.GetPrim().GetPrimPath():
+                        rigidbody_found = True
+                        # The collider below the disabled nested body belongs
+                        # to the enabled body above it.
+                        self.assertTrue(len(desc.collisions) == 1)
+                        self.assertTrue(desc.collisions[0] ==
+                                        cube.GetPrim().GetPrimPath())
+                    elif prim_path == disabled_body.GetPrim().GetPrimPath():
+                        # The disabled body owns no colliders.
+                        self.assertTrue(len(desc.collisions) == 0)
+            elif key == UsdPhysics.ObjectType.CubeShape:
+                for prim_path, desc in zip(prim_paths, descs):
+                    cube_found = True
+                    self.assertTrue(prim_path == cube.GetPrim().GetPrimPath())
+                    self.assertTrue(desc.rigidBody ==
+                                    rigidbody.GetPrim().GetPrimPath())
+
+        self.assertTrue(rigidbody_found)
+        self.assertTrue(cube_found)
+
     def test_rigidbody_collision_multithreading_parse(self):
         """Check that if a single rigid body has many collision objects, the
         multithreaded parsing works correctly.

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -560,6 +560,37 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
                                 
         self.compare_mass_information(rigidBodyAPI, 1000.0 * 2.0, expectedCoM=Gf.Vec3f(0.0))
 
+    # A collider with physics:collisionEnabled = false is not enabled and
+    # takes no part in simulation, so it must not contribute to the aggregated
+    # mass. A body whose only enabled collider is a unit cube should report the
+    # same mass, center of mass, and inertia as if the disabled collider were
+    # absent.
+    def test_mass_rigid_body_cube_disabled_collider(self):
+        self.setup_scene()
+
+        # top level xform - rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Enabled collider cube0 at the origin.
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+
+        # Disabled collider cube1, offset so that if it were (incorrectly)
+        # included it would both change the mass and shift the center of mass.
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        disabledCollisionAPI = UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+        disabledCollisionAPI.GetCollisionEnabledAttr().Set(False)
+        self.cube2.AddTranslateOp().Set(Gf.Vec3f(0, 0, 4.0))
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Only the single enabled unit cube (default density 1000) contributes.
+        self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
+
     def test_mass_rigid_body_nested(self):
         self.setup_scene()
 

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -591,6 +591,83 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
         # Only the single enabled unit cube (default density 1000) contributes.
         self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
 
+    # A nested rigid body only forms the root of its own subtree while it is
+    # enabled. A nested body whose physics:rigidBodyEnabled is false takes no
+    # part in simulation and therefore owns no colliders, so the enabled
+    # colliders below it still belong to the nearest enabled body above it and
+    # must still contribute their mass to it. Were the disabled body's subtree
+    # pruned instead, that mass would be attributed to no body at all.
+    def test_mass_rigid_body_disabled_nested_body(self):
+        self.setup_scene()
+
+        # top level xform - enabled rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Enabled collider cube0, owned directly by the top level body.
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+        self.cube.AddTranslateOp().Set(Gf.Vec3f(0, 0, -2.0))
+
+        # Disabled nested rigid body, offset from the top level body.
+        disabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody")
+        disabledBodyAPI = UsdPhysics.RigidBodyAPI.Apply(disabledBodyXform.GetPrim())
+        disabledBodyAPI.GetRigidBodyEnabledAttr().Set(False)
+        disabledBodyXform.AddTranslateOp().Set(Gf.Vec3f(0, 0, 2.0))
+
+        # Enabled collider cube1, below the disabled nested body.
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Both unit cubes (default density 1000) contribute, and they are
+        # placed symmetrically about the top level body's origin. This matches
+        # test_mass_rigid_body_cube_compound, where the same two colliders are
+        # owned directly by the body.
+        self.compare_mass_information(rigidBodyAPI, 1000.0 * 2.0, expectedCoM=Gf.Vec3f(0.0))
+
+    # A disabled nested rigid body must not shadow an enabled body above it for
+    # colliders that sit even deeper in the hierarchy, and an enabled body below
+    # a disabled one must still own its own colliders.
+    def test_mass_rigid_body_disabled_nested_body_deep(self):
+        self.setup_scene()
+
+        # top level xform - enabled rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Disabled nested rigid body.
+        disabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody")
+        disabledBodyAPI = UsdPhysics.RigidBodyAPI.Apply(disabledBodyXform.GetPrim())
+        disabledBodyAPI.GetRigidBodyEnabledAttr().Set(False)
+
+        # Enabled collider nested under an intermediate Xform below the
+        # disabled body, so the traversal has to continue past both.
+        UsdGeom.Xform.Define(self.stage, "/xform/disabledBody/group")
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/group/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+
+        # An enabled nested body below the disabled one still forms the root of
+        # its own subtree, so its collider belongs to it and not to /xform.
+        enabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody/enabledBody")
+        UsdPhysics.RigidBodyAPI.Apply(enabledBodyXform.GetPrim())
+        enabledBodyXform.AddTranslateOp().Set(Gf.Vec3f(0, 0, 4.0))
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/enabledBody/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Only cube0 contributes to /xform: cube1 belongs to the enabled
+        # nested body, whose subtree is still pruned.
+        self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
+
     def test_mass_rigid_body_nested(self):
         self.setup_scene()
 


### PR DESCRIPTION
### Description of Change(s)

`UsdPhysicsRigidBodyAPI::ComputeMassProperties` gathers the colliders beneath a rigid body to compute its aggregated mass, center of mass, and inertia. The gathering loop collected every descendant prim with `PhysicsCollisionAPI` applied without checking whether that collider was actually enabled, so a collider with `physics:collisionEnabled = false` still contributed to the body's mass properties.

Per the [`UsdPhysicsCollisionAPI` documentation](https://openusd.org/release/api/class_usd_physics_collision_a_p_i.html), `physics:collisionEnabled` "Determines if the PhysicsCollisionAPI is enabled." A collider whose collision is disabled takes no part in simulation, so it should not contribute to the body's aggregated mass, center of mass, or inertia.

This change skips colliders whose resolved `physics:collisionEnabled` is `false` when gathering shapes for the mass computer. Enabled colliders (including those relying on the `true` schema fallback) are unaffected.

**Observed behavior before/after** — a rigid body with one enabled unit cube and one disabled unit cube offset along z:

| | mass | center of mass |
|---|---|---|
| before | 2000 (both cubes) | (0, 0, 2) — shifted by the disabled cube |
| after | 1000 (enabled cube only) | (0, 0, 0) |

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A — bug fix in existing behavior, no schema or API change.

### Fixes Issue(s)

- Disabled colliders (`physics:collisionEnabled = false`) incorrectly contributing to `ComputeMassProperties` mass aggregation.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
