### PR TITLE
testenv/smallVector: avoid aggressive loop optimization warnings

### DIFF
--- a/pxr/base/tf/testenv/smallVector.cpp
+++ b/pxr/base/tf/testenv/smallVector.cpp
@@ -1046,10 +1046,10 @@ struct TestStruct
     }
 
     int _value;
-    static int counter;
+    static uint32_t counter;
 };
 
-int TestStruct::counter = 0;
+uint32_t TestStruct::counter = 0;
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
gcc (Debian 15.3.0-1) 15.3.0 and warns about undefined behavior:

```
In copy constructor ‘TestStruct::TestStruct(const TestStruct&)’,
  inlined from ‘void std::_Construct(_Tp*, _Args&& ...)
          [with _Tp = TestStruct; _Args = {const TestStruct&}]’
          at /usr/include/c++/15/bits/stl_construct.h:133:7,
  ...
  inlined from ‘void TfSmallVector<T, N>::insert(iterator, ForwardIterator, ForwardIterator)
          [with ForwardIterator = const TestStruct*; T = TestStruct; unsigned int N = 15]’
          at pxr/base/tf/smallVector.h:579:36,
  inlined from ‘void TfSmallVector<T, N>::insert(iterator, std::initializer_list<_Tp>)
          [with T = TestStruct; unsigned int N = 15]’
          at pxr/base/tf/smallVector.h:588:15,
  inlined from ‘void testInsertion()’ at pxr/base/tf/testenv/smallVector.cpp:1212:21:
pxr/base/tf/testenv/smallVector.cpp:1036:16:
  warning: iteration 4294967295 invokes undefined behavior [-Waggressive-loop-optimizations]
 1036 |         counter++;
      |         ~~~~~~~^~
```

Avoid undefined behavior by switching the static counter to uint32_t.

### Description of Change(s)

### Fixes Issue(s)

- Avoids detected Undefined Behavior and possible miscompilation due to optimizations when building with GCC.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
