### PR TITLE
[APPLE] Enable roundtriping of `Infinity` and `NaN` in JSON serialization library

### DIFF
--- a/pxr/base/js/json.cpp
+++ b/pxr/base/js/json.cpp
@@ -158,7 +158,7 @@ public:
     bool Double(double d) { 
         constexpr int bufferSize = 32;
         char buffer[bufferSize];
-        TfDoubleToString(d, buffer, bufferSize, true, "Inf", "NaN");
+        TfDoubleToString(d, buffer, bufferSize, true, "Infinity", "NaN");
         
         return Base::RawValue(buffer, strlen(buffer), rj::kNumberType);
      }

--- a/pxr/base/js/json.cpp
+++ b/pxr/base/js/json.cpp
@@ -288,7 +288,7 @@ JsParseStream(
     _LineTracker<rj::IStreamWrapper> isw(istr, buf.get(), bufLen);
     // Need Full precision flag to round trip double values correctly.
     constexpr auto parseFlags =
-        rj::kParseFullPrecisionFlag | rj::kParseStopWhenDoneFlag;
+        rj::kParseFullPrecisionFlag | rj::kParseStopWhenDoneFlag | rj::kParseNanAndInfFlag;
     rj::ParseResult result;
     if (error) {
         result = reader.Parse<parseFlags>(isw, handler);
@@ -332,7 +332,7 @@ JsParseString(
     rj::StringStream ss(data.c_str());
     // Need Full precision flag to round trip double values correctly.
     rj::ParseResult result =
-        reader.Parse<rj::kParseFullPrecisionFlag|rj::kParseStopWhenDoneFlag>(
+        reader.Parse<rj::kParseFullPrecisionFlag|rj::kParseStopWhenDoneFlag|rj::kParseNanAndInfFlag>(
             ss, handler);
 
     if (!result) {

--- a/pxr/base/js/json.cpp
+++ b/pxr/base/js/json.cpp
@@ -158,7 +158,7 @@ public:
     bool Double(double d) { 
         constexpr int bufferSize = 32;
         char buffer[bufferSize];
-        TfDoubleToString(d, buffer, bufferSize, true);
+        TfDoubleToString(d, buffer, bufferSize, true, "Inf", "NaN");
         
         return Base::RawValue(buffer, strlen(buffer), rj::kNumberType);
      }

--- a/pxr/base/js/rapidjson/reader.h
+++ b/pxr/base/js/rapidjson/reader.h
@@ -1521,14 +1521,14 @@ private:
                 }
         }
         // Parse NaN or Infinity here
-        else if ((parseFlags & kParseNanAndInfFlag) && RAPIDJSON_LIKELY((s.Peek() == 'I' || s.Peek() == 'i' || s.Peek() == 'N'))) {
+        else if ((parseFlags & kParseNanAndInfFlag) && RAPIDJSON_LIKELY((s.Peek() == 'I' || s.Peek() == 'N'))) {
             if (Consume(s, 'N')) {
                 if (Consume(s, 'a') && Consume(s, 'N')) {
                     d = std::numeric_limits<double>::quiet_NaN();
                     useNanOrInf = true;
                 }
             }
-            else if (RAPIDJSON_LIKELY(Consume(s, 'I') || Consume(s, 'i'))) {
+            else if (RAPIDJSON_LIKELY(Consume(s, 'I'))) {
                 if (Consume(s, 'n') && Consume(s, 'f')) {
                     d = (minus ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity());
                     useNanOrInf = true;

--- a/pxr/base/js/rapidjson/reader.h
+++ b/pxr/base/js/rapidjson/reader.h
@@ -1521,14 +1521,14 @@ private:
                 }
         }
         // Parse NaN or Infinity here
-        else if ((parseFlags & kParseNanAndInfFlag) && RAPIDJSON_LIKELY((s.Peek() == 'I' || s.Peek() == 'N'))) {
+        else if ((parseFlags & kParseNanAndInfFlag) && RAPIDJSON_LIKELY((s.Peek() == 'I' || s.Peek() == 'i' || s.Peek() == 'N'))) {
             if (Consume(s, 'N')) {
                 if (Consume(s, 'a') && Consume(s, 'N')) {
                     d = std::numeric_limits<double>::quiet_NaN();
                     useNanOrInf = true;
                 }
             }
-            else if (RAPIDJSON_LIKELY(Consume(s, 'I'))) {
+            else if (RAPIDJSON_LIKELY(Consume(s, 'I') || Consume(s, 'i'))) {
                 if (Consume(s, 'n') && Consume(s, 'f')) {
                     d = (minus ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity());
                     useNanOrInf = true;

--- a/pxr/base/js/testenv/testJsDouble.cpp
+++ b/pxr/base/js/testenv/testJsDouble.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <limits>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -24,7 +25,11 @@ void TestStreamInterface(const double d)
     std::cout << sstr.str() << std::endl;
     JsValue v2 = JsParseStream(sstr);
     TF_AXIOM(v2.IsReal());
-    TF_AXIOM(v2.GetReal() == d);
+    if (std::isnan(d)) {
+        TF_AXIOM(std::isnan(v2.GetReal()));
+    } else {
+        TF_AXIOM(v2.GetReal() == d);
+    }
 }
 
 void TestWriterInterface(const double d)
@@ -35,7 +40,11 @@ void TestWriterInterface(const double d)
     std::cout << sstr.str() << std::endl;
     JsValue v2 = JsParseStream(sstr);
     TF_AXIOM(v2.IsReal());
-    TF_AXIOM(v2.GetReal() == d);
+    if (std::isnan(d)) {
+        TF_AXIOM(std::isnan(v2.GetReal()));
+    } else {
+        TF_AXIOM(v2.GetReal() == d);
+    }
 }
 
 int main(int argc, char const *argv[])
@@ -43,4 +52,12 @@ int main(int argc, char const *argv[])
     const double d = 0.42745098039215684;
     TestStreamInterface(d);
     TestWriterInterface(d);
+
+    using limits = std::numeric_limits<double>;
+    TestStreamInterface(limits::infinity());
+    TestWriterInterface(limits::infinity());
+    TestStreamInterface(-limits::infinity());
+    TestWriterInterface(-limits::infinity());
+    TestStreamInterface(limits::quiet_NaN());
+    TestWriterInterface(limits::quiet_NaN());
 }

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -961,7 +961,7 @@ TfStringify(float val)
 
 bool
 TfDoubleToString(
-    double val, char* buffer, int bufferSize, bool emitTrailingZero)
+    double val, char* buffer, int bufferSize, bool emitTrailingZero, std::string infinitySymbol, std::string nanSymbol)
 {
     if (bufferSize < 25) {
         return false;
@@ -974,8 +974,8 @@ TfDoubleToString(
     }
     const DSC conv(
         flags,
-        "inf", 
-        "nan",
+        infinitySymbol.c_str(),
+        nanSymbol.c_str(),
         'e',
         /* decimal_in_shortest_low */ -6,
         /* decimal_in_shortest_high */ 15,

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -588,7 +588,7 @@ TF_API std::string TfStringify(double);
 /// values can be represented.
 /// Returns whether the conversion was successful.
 TF_API bool TfDoubleToString(
-    double d, char* buffer, int len, bool emitTrailingZero);
+    double d, char* buffer, int len, bool emitTrailingZero, std::string infinitySymbol = "inf", std::string nanSymbol = "nan");
 
 /// \struct TfStreamFloat
 /// 

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <stdio.h>
 #include <locale>
+#include <limits>
 
 using namespace std;
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -82,6 +83,27 @@ TestNumbers()
     TF_AXIOM(strcmp(buffer, "-1.1111111111111113e-308") == 0);
     TF_AXIOM(
         !TfDoubleToString(-1.1111111111111113e-308, buffer, 24, true));
+
+    TF_AXIOM(
+        TfDoubleToString(std::numeric_limits<double>::infinity(), buffer, bufferSize, true));
+    TF_AXIOM(strcmp(buffer, "inf") == 0);
+    TF_AXIOM(
+        TfDoubleToString(-std::numeric_limits<double>::infinity(), buffer, bufferSize, true));
+    TF_AXIOM(strcmp(buffer, "-inf") == 0);
+    TF_AXIOM(
+        TfDoubleToString(std::numeric_limits<double>::quiet_NaN(), buffer, bufferSize, true));
+    TF_AXIOM(strcmp(buffer, "nan") == 0);
+
+    TF_AXIOM(
+        TfDoubleToString(std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Inf", "NaN"));
+    TF_AXIOM(strcmp(buffer, "Inf") == 0);
+    TF_AXIOM(
+        TfDoubleToString(-std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Inf", "NaN"));
+    TF_AXIOM(strcmp(buffer, "-Inf") == 0);
+    TF_AXIOM(
+        TfDoubleToString(std::numeric_limits<double>::quiet_NaN(), buffer, bufferSize, true, "Inf", "NaN"));
+    TF_AXIOM(strcmp(buffer, "NaN") == 0);
+
 
     return true;
 }

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -95,11 +95,11 @@ TestNumbers()
     TF_AXIOM(strcmp(buffer, "nan") == 0);
 
     TF_AXIOM(
-        TfDoubleToString(std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Inf", "NaN"));
-    TF_AXIOM(strcmp(buffer, "Inf") == 0);
+        TfDoubleToString(std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Infinity", "NaN"));
+    TF_AXIOM(strcmp(buffer, "Infinity") == 0);
     TF_AXIOM(
-        TfDoubleToString(-std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Inf", "NaN"));
-    TF_AXIOM(strcmp(buffer, "-Inf") == 0);
+        TfDoubleToString(-std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Infinity", "NaN"));
+    TF_AXIOM(strcmp(buffer, "-Infinity") == 0);
     TF_AXIOM(
         TfDoubleToString(std::numeric_limits<double>::quiet_NaN(), buffer, bufferSize, true, "Inf", "NaN"));
     TF_AXIOM(strcmp(buffer, "NaN") == 0);

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -101,7 +101,7 @@ TestNumbers()
         TfDoubleToString(-std::numeric_limits<double>::infinity(), buffer, bufferSize, true, "Infinity", "NaN"));
     TF_AXIOM(strcmp(buffer, "-Infinity") == 0);
     TF_AXIOM(
-        TfDoubleToString(std::numeric_limits<double>::quiet_NaN(), buffer, bufferSize, true, "Inf", "NaN"));
+        TfDoubleToString(std::numeric_limits<double>::quiet_NaN(), buffer, bufferSize, true, "Infinity", "NaN"));
     TF_AXIOM(strcmp(buffer, "NaN") == 0);
 
 


### PR DESCRIPTION
Posting on behalf of Maddy Adams

### Description of Change(s)
Enable rapidjson's NaN/Inf parse flag and accept the lowercase "inf" spelling emitted by TfDoubleToString, so non-finite doubles round trip through JsWriteToStream/JsParseStream.

The JSON specification doesn't allow for writing `inf` - but OpenUSD is already writing them - so I don't think we are any less spec compliant

### Link to proposal 
None

### Fixes Issue(s)
Cannot round-trip files that have `inf` in using JsWriteToStream/JsParseStream

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
