### PR TITLE
DRAFT PR Fix: -Wunused-lambda-capture warnings flagged by CLang

### DIFF
--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -526,7 +526,7 @@ HdStCommandBuffer::SyncDrawItemVisibility(unsigned visChangeCount)
     tbb::enumerable_thread_specific<size_t> visCounts;
 
     WorkParallelForN(_drawItemInstances.size()/N+1,
-      [&visCounts, this, N](size_t start, size_t end) {
+      [&visCounts, this](size_t start, size_t end) {
         TRACE_SCOPE("SetVis");
         start *= N;
         end = std::min(end*N, _drawItemInstances.size());

--- a/pxr/imaging/hdx/selectionTracker.cpp
+++ b/pxr/imaging/hdx/selectionTracker.cpp
@@ -467,7 +467,7 @@ HdxSelectionTracker::_GetSelectionOffsets(HdSelectionSharedPtr const &selection,
 
     size_t const N = 1000;
     WorkParallelForN(numPrims/N + 1,
-       [&ids, index, N, &selectedPrims](size_t begin, size_t end) mutable {
+       [&ids, index, &selectedPrims](size_t begin, size_t end) mutable {
         end = std::min(end*N, ids.size());
         begin = begin*N;
         for (size_t i = begin; i < end; i++) {

--- a/pxr/usd/usdGeom/basisCurves.cpp
+++ b/pxr/usd/usdGeom/basisCurves.cpp
@@ -385,13 +385,13 @@ UsdGeomBasisCurves::ComputeSegmentCounts(
             if (wrap == UsdGeomTokens->periodic) {
                 // Cubic, bezier, periodic
                 std::transform(curveVertexCounts.cbegin(), curveVertexCounts.cend(), 
-                    segmentCounts.begin(), [vstep](int n) { return n / vstep; });
+                    segmentCounts.begin(), [](int n) { return n / vstep; });
                 isValid = true;
             } else if (wrap == UsdGeomTokens->nonperiodic || 
                     wrap == UsdGeomTokens->pinned) {
                 // Cubic, bezier, nonperiodic/pinned
                 std::transform(curveVertexCounts.cbegin(), curveVertexCounts.cend(), 
-                    segmentCounts.begin(), [vstep](int n) { return (n - 4) / vstep + 1; });
+                    segmentCounts.begin(), [](int n) { return (n - 4) / vstep + 1; });
                 isValid = true;
             }
         } else if (basis == UsdGeomTokens->bspline ||


### PR DESCRIPTION
Removed unsused lambda captures to clean up compilation warnings with CLang

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
