### PR TITLE
usdPhysics: treat disabled rigid bodies as unapplied in all ancestor traversals

### DIFF
--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -37,16 +37,14 @@ class SdfAssetPath;
 ///
 /// Defines explicit mass properties (mass, density, inertia etc.).        
 /// MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-/// a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
-/// PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
-/// physics:collisionEnabled is false, or a rigid body whose
-/// physics:rigidBodyEnabled is false, takes no part in simulation, so any
-/// MassAPI applied to it is likewise ignored. When neither an enabled
-/// collider nor an enabled rigid body remains on a prim, it is not a physics
-/// prim and its MassAPI has no effect. Note that this concerns only the prim
-/// the MassAPI is applied to: disabling a prim does not discard the mass of
-/// the enabled colliders beneath it, which continue to contribute to the
-/// nearest enabled rigid body above them.
+/// a PhysicsRigidBodyAPI, and takes effect only while that collider or rigid
+/// body is enabled. A prim whose physics:collisionEnabled or
+/// physics:rigidBodyEnabled is false is not simulated, and its MassAPI is
+/// ignored.
+///
+/// This applies only to the prim the MassAPI is applied to. Enabled colliders
+/// beneath it are unaffected and still contribute their mass to the nearest
+/// enabled rigid body above them.
 ///
 class UsdPhysicsMassAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -43,7 +43,10 @@ class SdfAssetPath;
 /// physics:rigidBodyEnabled is false, takes no part in simulation, so any
 /// MassAPI applied to it is likewise ignored. When neither an enabled
 /// collider nor an enabled rigid body remains on a prim, it is not a physics
-/// prim and its MassAPI has no effect.
+/// prim and its MassAPI has no effect. Note that this concerns only the prim
+/// the MassAPI is applied to: disabling a prim does not discard the mass of
+/// the enabled colliders beneath it, which continue to contribute to the
+/// nearest enabled rigid body above them.
 ///
 class UsdPhysicsMassAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -37,7 +37,13 @@ class SdfAssetPath;
 ///
 /// Defines explicit mass properties (mass, density, inertia etc.).        
 /// MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-/// a PhysicsRigidBodyAPI.
+/// a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
+/// PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
+/// physics:collisionEnabled is false, or a rigid body whose
+/// physics:rigidBodyEnabled is false, takes no part in simulation, so any
+/// MassAPI applied to it is likewise ignored. When neither an enabled
+/// collider nor an enabled rigid body remains on a prim, it is not a physics
+/// prim and its MassAPI has no effect.
 ///
 class UsdPhysicsMassAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -319,15 +319,14 @@ a prim higher in the tree, overrides any density specified via a material
 times the locally effective density.
 
 \li Implicit mass of a rigid body is the total implicit mass of all children in
-the subtree belonging to the rigid body. Only enabled colliders are counted
-among these children: a collider whose physics:collisionEnabled is false takes
-no part in simulation and is excluded from the mass computation, so any
-UsdPhysicsMassAPI applied to it has no effect. Likewise, a UsdPhysicsMassAPI
-applied to a nested rigid body whose physics:rigidBodyEnabled is false has no
-effect. Note however that a disabled nested rigid body does not itself form the
-root of a subtree: because it takes no part in simulation it owns no colliders,
-so the enabled colliders below it still belong to the nearest enabled rigid body
-above it and still contribute their mass to it.
+the subtree belonging to the rigid body. Only enabled colliders count toward
+that total. A collider whose physics:collisionEnabled is false is not simulated,
+and any UsdPhysicsMassAPI applied to it is ignored, as is a UsdPhysicsMassAPI
+applied to a disabled nested rigid body.
+
+\li A disabled nested rigid body does not, however, exclude the colliders
+beneath it. It owns no colliders while it is disabled, so those colliders belong
+to the nearest enabled rigid body above it and contribute that body's mass.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -313,7 +313,11 @@ a prim higher in the tree, overrides any density specified via a material
 times the locally effective density.
 
 \li Implicit mass of a rigid body is the total implicit mass of all children in
-the subtree belonging to the rigid body.
+the subtree belonging to the rigid body. Only enabled colliders are counted
+among these children: a collider whose physics:collisionEnabled is false, or a
+child rigid body whose physics:rigidBodyEnabled is false, takes no part in
+simulation and is excluded from the mass computation, so any UsdPhysicsMassAPI
+applied to it has no effect.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -226,7 +226,8 @@ of a rigid body that are not parts of other rigid bodies. Multiple rigid bodies
 in a subtree move completely independently, even if their transforms are stored
 relative to one another.  
 
-This exception applies only while the nested UsdPhysicsRigidBodyAPI is enabled.
+This exception applies only while the prim to which UsdPhysicsRigidBodyAPI is
+applied has physics:rigidBodyEnabled enabled.
 A nested rigid body whose physics:rigidBodyEnabled is false takes no part in
 simulation and therefore does not create a separate rigid body, so it does not
 form the root of its own subtree; the prims below it remain part of the nearest
@@ -322,11 +323,12 @@ times the locally effective density.
 the subtree belonging to the rigid body. Only enabled colliders count toward
 that total. A collider whose physics:collisionEnabled is false is not simulated,
 and any UsdPhysicsMassAPI applied to it is ignored, as is a UsdPhysicsMassAPI
-applied to a disabled nested rigid body.
+applied to a rigid body whose physics:rigidBodyEnabled is false.
 
-\li A disabled nested rigid body does not, however, exclude the colliders
-beneath it. It owns no colliders while it is disabled, so those colliders belong
-to the nearest enabled rigid body above it and contribute that body's mass.
+\li A rigid body whose physics:rigidBodyEnabled is false does not, however,
+exclude the colliders beneath it. It owns no colliders while it is disabled, so
+those colliders belong to the nearest enabled rigid body above it and contribute
+that body's mass.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/overview.dox
+++ b/pxr/usd/usdPhysics/overview.dox
@@ -226,6 +226,12 @@ of a rigid body that are not parts of other rigid bodies. Multiple rigid bodies
 in a subtree move completely independently, even if their transforms are stored
 relative to one another.  
 
+This exception applies only while the nested UsdPhysicsRigidBodyAPI is enabled.
+A nested rigid body whose physics:rigidBodyEnabled is false takes no part in
+simulation and therefore does not create a separate rigid body, so it does not
+form the root of its own subtree; the prims below it remain part of the nearest
+enabled rigid body above it in the hierarchy.
+
 If aggregate properties of the entire rigid body must be computed, such as
 total mass or the entirety of its collision volume, then the contents of the
 entire subtree are considered, taking care to exclude the contents of any
@@ -314,10 +320,14 @@ times the locally effective density.
 
 \li Implicit mass of a rigid body is the total implicit mass of all children in
 the subtree belonging to the rigid body. Only enabled colliders are counted
-among these children: a collider whose physics:collisionEnabled is false, or a
-child rigid body whose physics:rigidBodyEnabled is false, takes no part in
-simulation and is excluded from the mass computation, so any UsdPhysicsMassAPI
-applied to it has no effect.
+among these children: a collider whose physics:collisionEnabled is false takes
+no part in simulation and is excluded from the mass computation, so any
+UsdPhysicsMassAPI applied to it has no effect. Likewise, a UsdPhysicsMassAPI
+applied to a nested rigid body whose physics:rigidBodyEnabled is false has no
+effect. Note however that a disabled nested rigid body does not itself form the
+root of a subtree: because it takes no part in simulation it owns no colliders,
+so the enabled colliders below it still belong to the nearest enabled rigid body
+above it and still contribute their mass to it.
 
 \li Density is assumed to be 1000.0 kg/m3 (approximately the density of water) 
 for volume computation when no other density is specified locally, or in bound 

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -1644,7 +1644,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
 {
     bool physicsAPIFound = false;
     UsdPrim parent = usdPrim;
-    UsdPrim disabledBodyPrim = UsdPrim();
+    UsdPrim disabledBodyPrim;
     while (parent != usdPrim.GetStage()->GetPseudoRoot())
     {
         if (_IsDynamicBody(parent, bodyMap, &physicsAPIFound))
@@ -1660,7 +1660,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
             // disabled body may still have an enabled body above it, which
             // this prim belongs to. Remember the nearest disabled body so it
             // can still be reported if no enabled body is found at all.
-            if (disabledBodyPrim)
+            if (!disabledBodyPrim)
             {
                 disabledBodyPrim = parent;
             }
@@ -1672,7 +1672,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
     // No enabled body above this prim. Report the nearest disabled body, if
     // any, so it is still recognized as belonging to a body that is present
     // but not simulating rather than as a static collision.
-    if (!disabledBodyPrim)
+    if (disabledBodyPrim)
     {
         *outBodyPrimPath = disabledBodyPrim;
     }

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -1635,6 +1635,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
 {
     bool physicsAPIFound = false;
     UsdPrim parent = usdPrim;
+    UsdPrim disabledBodyPrim = UsdPrim();
     while (parent != usdPrim.GetStage()->GetPseudoRoot())
     {
         if (_IsDynamicBody(parent, bodyMap, &physicsAPIFound))
@@ -1645,11 +1646,26 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
 
         if (physicsAPIFound)
         {
-            *outBodyPrimPath = parent;
-            return false;
+            // A disabled rigid body takes no part in simulation, so it does
+            // not own this prim. Keep searching the ancestors: a nested
+            // disabled body may still have an enabled body above it, which
+            // this prim belongs to. Remember the nearest disabled body so it
+            // can still be reported if no enabled body is found at all.
+            if (disabledBodyPrim == UsdPrim())
+            {
+                disabledBodyPrim = parent;
+            }
         }
 
         parent = parent.GetParent();
+    }
+
+    // No enabled body above this prim. Report the nearest disabled body, if
+    // any, so it is still recognized as belonging to a body that is present
+    // but not simulating rather than as a static collision.
+    if (disabledBodyPrim != UsdPrim())
+    {
+        *outBodyPrimPath = disabledBodyPrim;
     }
     return false;
 }

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -944,9 +944,18 @@ UsdPrim _GetBodyPrim(UsdStageWeakPtr stage, const SdfPath& relPath,
     UsdPrim collisionPrim = UsdPrim();
     while (parent && parent != stage->GetPseudoRoot())
     {
-        if (parent.HasAPI<UsdPhysicsRigidBodyAPI>())
+        const UsdPhysicsRigidBodyAPI rigidBodyAPI(parent);
+        if (rigidBodyAPI)
         {
-            return parent;
+            // A disabled body takes no part in simulation and does not own
+            // this prim, so keep searching the ancestors as though the API
+            // were not applied at all.
+            bool rigidBodyEnabled = true;
+            rigidBodyAPI.GetRigidBodyEnabledAttr().Get(&rigidBodyEnabled);
+            if (rigidBodyEnabled)
+            {
+                return parent;
+            }
         }
         if (parent.HasAPI<UsdPhysicsCollisionAPI>())
         {

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -1660,7 +1660,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
             // disabled body may still have an enabled body above it, which
             // this prim belongs to. Remember the nearest disabled body so it
             // can still be reported if no enabled body is found at all.
-            if (disabledBodyPrim == UsdPrim())
+            if (disabledBodyPrim)
             {
                 disabledBodyPrim = parent;
             }
@@ -1672,7 +1672,7 @@ bool _HasDynamicBodyParent(const UsdPrim& usdPrim, const RigidBodyMap& bodyMap,
     // No enabled body above this prim. Report the nearest disabled body, if
     // any, so it is still recognized as belonging to a body that is present
     // but not simulating rather than as a static collision.
-    if (disabledBodyPrim != UsdPrim())
+    if (!disabledBodyPrim)
     {
         *outBodyPrimPath = disabledBodyPrim;
     }

--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -498,6 +498,14 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
 
             if (collisionPrim && collisionPrim.HasAPI<UsdPhysicsCollisionAPI>())
             {
+                const UsdPhysicsCollisionAPI collisionAPI(collisionPrim);
+                bool collisionEnabled = true;
+                collisionAPI.GetCollisionEnabledAttr().Get(&collisionEnabled);
+                if (!collisionEnabled)
+                {
+                    continue;
+                }
+
                 collisionPrims.push_back(std::move(collisionPrim));
             }
         }

--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -490,10 +490,21 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
             if (collisionPrim && collisionPrim != usdPrim && 
                 collisionPrim.HasAPI<UsdPhysicsRigidBodyAPI>())
             {
-                it.PruneChildren(); // Skip the subtree rooted at this prim, 
-                                    // the colliders belong to a different rigid 
-                                    // body
-                continue;
+                // A nested rigid body only forms the root of its own subtree
+                // while it is enabled. A disabled body takes no part in 
+                // simulation, so it does not own colliders; its subtree still 
+                // belongs to this body and must be traversed, otherwise the 
+                // colliders below it would contribute mass to no body at all.
+                const UsdPhysicsRigidBodyAPI nestedBodyAPI(collisionPrim);
+                bool nestedBodyEnabled = true;
+                nestedBodyAPI.GetRigidBodyEnabledAttr().Get(&nestedBodyEnabled);
+                if (nestedBodyEnabled)
+                {
+                    it.PruneChildren(); // Skip the subtree rooted at this prim, 
+                                        // the colliders belong to a different 
+                                        // rigid body
+                    continue;
+                }
             }
 
             if (collisionPrim && collisionPrim.HasAPI<UsdPhysicsCollisionAPI>())

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -208,7 +208,10 @@ class "PhysicsMassAPI"
     physics:rigidBodyEnabled is false, takes no part in simulation, so any
     MassAPI applied to it is likewise ignored. When neither an enabled
     collider nor an enabled rigid body remains on a prim, it is not a physics
-    prim and its MassAPI has no effect."""
+    prim and its MassAPI has no effect. Note that this concerns only the prim
+    the MassAPI is applied to: disabling a prim does not discard the mass of
+    the enabled colliders beneath it, which continue to contribute to the
+    nearest enabled rigid body above them."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -202,7 +202,13 @@ class "PhysicsMassAPI"
 
     doc = """Defines explicit mass properties (mass, density, inertia etc.).        
     MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-    a PhysicsRigidBodyAPI."""
+    a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
+    PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
+    physics:collisionEnabled is false, or a rigid body whose
+    physics:rigidBodyEnabled is false, takes no part in simulation, so any
+    MassAPI applied to it is likewise ignored. When neither an enabled
+    collider nor an enabled rigid body remains on a prim, it is not a physics
+    prim and its MassAPI has no effect."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -202,16 +202,14 @@ class "PhysicsMassAPI"
 
     doc = """Defines explicit mass properties (mass, density, inertia etc.).        
     MassAPI can be applied to any object that has a PhysicsCollisionAPI or
-    a PhysicsRigidBodyAPI. MassAPI only has an effect where the underlying
-    PhysicsCollisionAPI or PhysicsRigidBodyAPI is enabled; a collider whose
-    physics:collisionEnabled is false, or a rigid body whose
-    physics:rigidBodyEnabled is false, takes no part in simulation, so any
-    MassAPI applied to it is likewise ignored. When neither an enabled
-    collider nor an enabled rigid body remains on a prim, it is not a physics
-    prim and its MassAPI has no effect. Note that this concerns only the prim
-    the MassAPI is applied to: disabling a prim does not discard the mass of
-    the enabled colliders beneath it, which continue to contribute to the
-    nearest enabled rigid body above them."""
+    a PhysicsRigidBodyAPI, and takes effect only while that collider or rigid
+    body is enabled. A prim whose physics:collisionEnabled or
+    physics:rigidBodyEnabled is false is not simulated, and its MassAPI is
+    ignored.
+
+    This applies only to the prim the MassAPI is applied to. Enabled colliders
+    beneath it are unaffected and still contribute their mass to the nearest
+    enabled rigid body above them."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -565,6 +565,41 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
+    def test_rigidbody_disabled_body_only_collision_parse(self):
+        """With no enabled rigid body above it, a collider below a disabled
+        body is still reported as belonging to that body. It is present but not
+        simulating, which is distinct from a static collision.
+        """
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        disabled_body = UsdGeom.Xform.Define(stage, "/disabledBody")
+        disabled_body_api = UsdPhysics.RigidBodyAPI.Apply(
+            disabled_body.GetPrim())
+        disabled_body_api.GetRigidBodyEnabledAttr().Set(False)
+
+        cube = UsdGeom.Cube.Define(stage, "/disabledBody/cube")
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+        ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(stage, ["/"])
+
+        cube_found = False
+
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.CubeShape:
+                for prim_path, desc in zip(prim_paths, descs):
+                    cube_found = True
+                    self.assertTrue(prim_path == cube.GetPrim().GetPrimPath())
+                    # The nearest disabled body is reported rather than an
+                    # empty path, which would make this a static collision.
+                    self.assertTrue(desc.rigidBody ==
+                                    disabled_body.GetPrim().GetPrimPath())
+
+        self.assertTrue(cube_found)
+
     def test_joint_disabled_body_rel_parse(self):
         """A joint body relationship resolves to the nearest enabled rigid body
         above its target. A disabled body is treated as though the API were not

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -565,6 +565,63 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
+    def test_joint_disabled_body_rel_parse(self):
+        """A joint body relationship resolves to the nearest enabled rigid body
+        above its target. A disabled body is treated as though the API were not
+        applied at all, so it is skipped in favour of an enabled body above it.
+        """
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        rigidbody = UsdGeom.Xform.Define(stage, "/rigidBody")
+        UsdPhysics.RigidBodyAPI.Apply(rigidbody.GetPrim())
+
+        disabled_body = UsdGeom.Xform.Define(stage, "/rigidBody/disabledBody")
+        disabled_body_api = UsdPhysics.RigidBodyAPI.Apply(
+            disabled_body.GetPrim())
+        disabled_body_api.GetRigidBodyEnabledAttr().Set(False)
+
+        cube = UsdGeom.Cube.Define(stage, "/rigidBody/disabledBody/cube")
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+        joint = UsdPhysics.FixedJoint.Define(stage, "/joint")
+        joint.GetBody0Rel().AddTarget(cube.GetPrim().GetPrimPath())
+
+        ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(stage, ["/"])
+
+        joint_found = False
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.FixedJoint:
+                for prim_path, desc in zip(prim_paths, descs):
+                    joint_found = True
+                    # The disabled body is skipped, so the relationship
+                    # resolves to the enabled body above it.
+                    self.assertTrue(desc.body0 ==
+                                    rigidbody.GetPrim().GetPrimPath())
+
+        self.assertTrue(joint_found)
+
+        # With no enabled body above the target, the relationship no longer
+        # resolves to a body.
+        UsdPhysics.RigidBodyAPI(
+            rigidbody.GetPrim()).GetRigidBodyEnabledAttr().Set(False)
+
+        ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(stage, ["/"])
+
+        joint_found = False
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.FixedJoint:
+                for prim_path, desc in zip(prim_paths, descs):
+                    joint_found = True
+                    self.assertTrue(desc.body0 !=
+                                    rigidbody.GetPrim().GetPrimPath())
+
+        self.assertTrue(joint_found)
+
     def test_rigidbody_collision_multithreading_parse(self):
         """Check that if a single rigid body has many collision objects, the
         multithreaded parsing works correctly.

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -512,6 +512,59 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
+    def test_rigidbody_disabled_nested_body_collision_parse(self):
+        """A nested rigid body only owns colliders while it is enabled. A
+        collider below a disabled nested body must be reported as belonging to
+        the nearest enabled rigid body above it, matching the subtree that
+        UsdPhysicsRigidBodyAPI::ComputeMassProperties aggregates.
+        """
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        rigidbody = UsdGeom.Xform.Define(stage, "/rigidBody")
+        UsdPhysics.RigidBodyAPI.Apply(rigidbody.GetPrim())
+
+        # Disabled nested rigid body: it takes no part in simulation, so it
+        # does not form the root of its own subtree.
+        disabled_body = UsdGeom.Xform.Define(stage, "/rigidBody/disabledBody")
+        disabled_body_api = UsdPhysics.RigidBodyAPI.Apply(
+            disabled_body.GetPrim())
+        disabled_body_api.GetRigidBodyEnabledAttr().Set(False)
+
+        cube = UsdGeom.Cube.Define(stage, "/rigidBody/disabledBody/cube")
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+        ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(stage, ["/"])
+
+        rigidbody_found = False
+        cube_found = False
+
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.RigidBody:
+                for prim_path, desc in zip(prim_paths, descs):
+                    if prim_path == rigidbody.GetPrim().GetPrimPath():
+                        rigidbody_found = True
+                        # The collider below the disabled nested body belongs
+                        # to the enabled body above it.
+                        self.assertTrue(len(desc.collisions) == 1)
+                        self.assertTrue(desc.collisions[0] ==
+                                        cube.GetPrim().GetPrimPath())
+                    elif prim_path == disabled_body.GetPrim().GetPrimPath():
+                        # The disabled body owns no colliders.
+                        self.assertTrue(len(desc.collisions) == 0)
+            elif key == UsdPhysics.ObjectType.CubeShape:
+                for prim_path, desc in zip(prim_paths, descs):
+                    cube_found = True
+                    self.assertTrue(prim_path == cube.GetPrim().GetPrimPath())
+                    self.assertTrue(desc.rigidBody ==
+                                    rigidbody.GetPrim().GetPrimPath())
+
+        self.assertTrue(rigidbody_found)
+        self.assertTrue(cube_found)
+
     def test_rigidbody_collision_multithreading_parse(self):
         """Check that if a single rigid body has many collision objects, the
         multithreaded parsing works correctly.

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -560,6 +560,37 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
                                 
         self.compare_mass_information(rigidBodyAPI, 1000.0 * 2.0, expectedCoM=Gf.Vec3f(0.0))
 
+    # A collider with physics:collisionEnabled = false is not enabled and
+    # takes no part in simulation, so it must not contribute to the aggregated
+    # mass. A body whose only enabled collider is a unit cube should report the
+    # same mass, center of mass, and inertia as if the disabled collider were
+    # absent.
+    def test_mass_rigid_body_cube_disabled_collider(self):
+        self.setup_scene()
+
+        # top level xform - rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Enabled collider cube0 at the origin.
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+
+        # Disabled collider cube1, offset so that if it were (incorrectly)
+        # included it would both change the mass and shift the center of mass.
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        disabledCollisionAPI = UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+        disabledCollisionAPI.GetCollisionEnabledAttr().Set(False)
+        self.cube2.AddTranslateOp().Set(Gf.Vec3f(0, 0, 4.0))
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Only the single enabled unit cube (default density 1000) contributes.
+        self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
+
     def test_mass_rigid_body_nested(self):
         self.setup_scene()
 

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -591,6 +591,83 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
         # Only the single enabled unit cube (default density 1000) contributes.
         self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
 
+    # A nested rigid body only forms the root of its own subtree while it is
+    # enabled. A nested body whose physics:rigidBodyEnabled is false takes no
+    # part in simulation and therefore owns no colliders, so the enabled
+    # colliders below it still belong to the nearest enabled body above it and
+    # must still contribute their mass to it. Were the disabled body's subtree
+    # pruned instead, that mass would be attributed to no body at all.
+    def test_mass_rigid_body_disabled_nested_body(self):
+        self.setup_scene()
+
+        # top level xform - enabled rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Enabled collider cube0, owned directly by the top level body.
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+        self.cube.AddTranslateOp().Set(Gf.Vec3f(0, 0, -2.0))
+
+        # Disabled nested rigid body, offset from the top level body.
+        disabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody")
+        disabledBodyAPI = UsdPhysics.RigidBodyAPI.Apply(disabledBodyXform.GetPrim())
+        disabledBodyAPI.GetRigidBodyEnabledAttr().Set(False)
+        disabledBodyXform.AddTranslateOp().Set(Gf.Vec3f(0, 0, 2.0))
+
+        # Enabled collider cube1, below the disabled nested body.
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Both unit cubes (default density 1000) contribute, and they are
+        # placed symmetrically about the top level body's origin. This matches
+        # test_mass_rigid_body_cube_compound, where the same two colliders are
+        # owned directly by the body.
+        self.compare_mass_information(rigidBodyAPI, 1000.0 * 2.0, expectedCoM=Gf.Vec3f(0.0))
+
+    # A disabled nested rigid body must not shadow an enabled body above it for
+    # colliders that sit even deeper in the hierarchy, and an enabled body below
+    # a disabled one must still own its own colliders.
+    def test_mass_rigid_body_disabled_nested_body_deep(self):
+        self.setup_scene()
+
+        # top level xform - enabled rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Disabled nested rigid body.
+        disabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody")
+        disabledBodyAPI = UsdPhysics.RigidBodyAPI.Apply(disabledBodyXform.GetPrim())
+        disabledBodyAPI.GetRigidBodyEnabledAttr().Set(False)
+
+        # Enabled collider nested under an intermediate Xform below the
+        # disabled body, so the traversal has to continue past both.
+        UsdGeom.Xform.Define(self.stage, "/xform/disabledBody/group")
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/group/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+
+        # An enabled nested body below the disabled one still forms the root of
+        # its own subtree, so its collider belongs to it and not to /xform.
+        enabledBodyXform = UsdGeom.Xform.Define(self.stage, "/xform/disabledBody/enabledBody")
+        UsdPhysics.RigidBodyAPI.Apply(enabledBodyXform.GetPrim())
+        enabledBodyXform.AddTranslateOp().Set(Gf.Vec3f(0, 0, 4.0))
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/disabledBody/enabledBody/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Only cube0 contributes to /xform: cube1 belongs to the enabled
+        # nested body, whose subtree is still pruned.
+        self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
+
     def test_mass_rigid_body_nested(self):
         self.setup_scene()
 

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -229,6 +229,151 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         self.assertTrue(len(errors) == 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
+    def test_physics_joint_enabled_rigid_body_on_ancestor(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:PhysicsJointChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        # A body relationship may target any UsdGeomXformable. Joint parsing
+        # resolves a target to its closest ancestor body, so a collider below
+        # an enabled body is a valid target.
+        body0 = UsdGeom.Xform.Define(stage, "/body0")
+        UsdPhysics.RigidBodyAPI.Apply(body0.GetPrim())
+        collider0 = UsdGeom.Cube.Define(stage, "/body0/collider")
+        UsdPhysics.CollisionAPI.Apply(collider0.GetPrim())
+
+        body1 = UsdGeom.Xform.Define(stage, "/body1")
+        rbo1 = UsdPhysics.RigidBodyAPI.Apply(body1.GetPrim())
+        collider1 = UsdGeom.Cube.Define(stage, "/body1/collider")
+        UsdPhysics.CollisionAPI.Apply(collider1.GetPrim())
+
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        physicsJoint.GetBody0Rel().AddTarget("/body0/collider")
+        physicsJoint.GetBody1Rel().AddTarget("/body1/collider")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Disabling the only enabled ancestor body fails the check
+        rbo0 = UsdPhysics.RigidBodyAPI(body0.GetPrim())
+        rbo0.GetRigidBodyEnabledAttr().Set(False)
+        rbo1.GetRigidBodyEnabledAttr().Set(False)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
+
+        # Re-enabling either one of the bodies satisfies the check
+        rbo0.GetRigidBodyEnabledAttr().Set(True)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        rbo0.GetRigidBodyEnabledAttr().Set(False)
+        rbo1.GetRigidBodyEnabledAttr().Set(True)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # An ancestor collider without any body in the hierarchy is not a body
+        stage = Usd.Stage.CreateInMemory()
+        group = UsdGeom.Xform.Define(stage, "/group")
+        collider = UsdGeom.Cube.Define(stage, "/group/collider")
+        UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
+
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        physicsJoint.GetBody0Rel().AddTarget("/group/collider")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
+
+    def test_physics_joint_enabled_rigid_body_nested(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:PhysicsJointChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        # Nested bodies: a disabled body is treated as though the API were not
+        # applied at all, so the search continues past it to an enabled
+        # ancestor body, matching joint and collider parsing
+        outerBody = UsdGeom.Xform.Define(stage, "/outer")
+        outerRbo = UsdPhysics.RigidBodyAPI.Apply(outerBody.GetPrim())
+        innerBody = UsdGeom.Xform.Define(stage, "/outer/inner")
+        innerRbo = UsdPhysics.RigidBodyAPI.Apply(innerBody.GetPrim())
+        collider = UsdGeom.Cube.Define(stage, "/outer/inner/collider")
+        UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
+
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        physicsJoint.GetBody0Rel().AddTarget("/outer/inner/collider")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Disabling the closest body still leaves the enabled outer body
+        innerRbo.GetRigidBodyEnabledAttr().Set(False)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Removing the disabled body entirely is equivalent
+        innerBody.GetPrim().RemoveAPI(UsdPhysics.RigidBodyAPI)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Only when no enabled body remains anywhere above does it fail
+        UsdPhysics.RigidBodyAPI.Apply(
+            innerBody.GetPrim()).GetRigidBodyEnabledAttr().Set(False)
+        outerRbo.GetRigidBodyEnabledAttr().Set(False)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
+
+    def test_physics_joint_enabled_rigid_body_non_body_rel(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:PhysicsJointChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        # Only one body relationship needs to reach an enabled body. The other
+        # may target a prim that is neither the world nor a body, such as an
+        # asset root prim.
+        assetRoot = UsdGeom.Xform.Define(stage, "/asset")
+        body = UsdGeom.Xform.Define(stage, "/asset/body")
+        rbo = UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/asset/joint")
+        physicsJoint.GetBody0Rel().AddTarget(assetRoot.GetPath())
+        physicsJoint.GetBody1Rel().AddTarget(body.GetPath())
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # ... but it cannot stand in for one, so disabling the only body fails
+        rbo.GetRigidBodyEnabledAttr().Set(False)
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
+
     def test_physics_joint_multiple_rels(self):
         validationRegistry = UsdValidation.ValidationRegistry()
         validator = validationRegistry.GetOrLoadValidatorByName(

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -26,7 +26,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         UsdPhysics.RigidBodyAPI.Apply(rigidbody.GetPrim())
 
         errors = validator.Validate(rigidbody.GetPrim())
-        self.assertTrue(len(errors) == 1)        
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "RigidBodyNonXformable")
 
     def test_rigid_body_orientation_scale(self):        
@@ -44,7 +44,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         UsdPhysics.RigidBodyAPI.Apply(rigidbody.GetPrim())
 
         errors = validator.Validate(rigidbody.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         transform = Gf.Transform()
         transform.SetScale(Gf.Vec3d(7,8,9))
@@ -54,7 +54,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         rigidbody.AddTransformOp().Set(matrix)
 
         errors = validator.Validate(rigidbody.GetPrim())
-        self.assertTrue(len(errors) == 1)        
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "RigidBodyOrientationScale")        
 
     def test_rigid_body_instancing(self):        
@@ -77,13 +77,13 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         xform.GetPrim().SetInstanceable(True)
 
         errors = validator.Validate(rigidbody.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
         
         instanceRigidBody = stage.GetPrimAtPath("/xformInstance/rigidBody")
         self.assertTrue(instanceRigidBody.IsInstanceProxy())        
 
         errors = validator.Validate(instanceRigidBody.GetPrim())
-        self.assertTrue(len(errors) == 1)        
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "RigidBodyNonInstanceable")
 
     def test_articulation_nesting(self):        
@@ -104,10 +104,10 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         UsdPhysics.ArticulationRootAPI.Apply(articulation1.GetPrim())
 
         errors = validator.Validate(articulation0.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         errors = validator.Validate(articulation1.GetPrim())
-        self.assertTrue(len(errors) == 1)        
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "NestedArticulation")        
 
     def test_articulation_body(self):        
@@ -127,19 +127,19 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         rboAPI = UsdPhysics.RigidBodyAPI.Apply(articulation.GetPrim())
 
         errors = validator.Validate(articulation.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         rboAPI.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(articulation.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ArticulationOnStaticBody")
 
         rboAPI.GetRigidBodyEnabledAttr().Set(True)
         rboAPI.GetKinematicEnabledAttr().Set(True)
 
         errors = validator.Validate(articulation.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
     def test_physics_joint_invalid_rel(self):
         validationRegistry = UsdValidation.ValidationRegistry()
@@ -160,7 +160,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget("/invalidPrim")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointInvalidPrimRel")
 
     def test_physics_joint_rel_not_xformable(self):
@@ -183,14 +183,14 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget("/xform")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointRelNotXformable")
 
         # Xform is Xformable — should not trigger JointRelNotXformable
         physicsJoint.GetBody0Rel().SetTargets(["/xform"])
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
     def test_physics_joint_requires_enabled_rigid_body(self):
         validationRegistry = UsdValidation.ValidationRegistry()
@@ -207,7 +207,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
         # Add one enabled rigid body — should clear the error
@@ -216,7 +216,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody0Rel().AddTarget("/body0")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Disable the rigid body — should fail again
         body1 = UsdGeom.Xform.Define(stage, "/body1")
@@ -226,7 +226,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget("/body1")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
     def test_physics_joint_enabled_rigid_body_on_ancestor(self):
@@ -258,7 +258,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget("/body1/collider")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Disabling the only enabled ancestor body fails the check
         rbo0 = UsdPhysics.RigidBodyAPI(body0.GetPrim())
@@ -266,20 +266,20 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         rbo1.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
         # Re-enabling either one of the bodies satisfies the check
         rbo0.GetRigidBodyEnabledAttr().Set(True)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         rbo0.GetRigidBodyEnabledAttr().Set(False)
         rbo1.GetRigidBodyEnabledAttr().Set(True)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # An ancestor collider without any body in the hierarchy is not a body
         stage = Usd.Stage.CreateInMemory()
@@ -291,7 +291,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody0Rel().AddTarget("/group/collider")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
     def test_physics_joint_enabled_rigid_body_nested(self):
@@ -319,19 +319,19 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody0Rel().AddTarget("/outer/inner/collider")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Disabling the closest body still leaves the enabled outer body
         innerRbo.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Removing the disabled body entirely is equivalent
         innerBody.GetPrim().RemoveAPI(UsdPhysics.RigidBodyAPI)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Only when no enabled body remains anywhere above does it fail
         UsdPhysics.RigidBodyAPI.Apply(
@@ -339,7 +339,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         outerRbo.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
     def test_physics_joint_enabled_rigid_body_non_body_rel(self):
@@ -365,13 +365,13 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget(body.GetPath())
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # ... but it cannot stand in for one, so disabling the only body fails
         rbo.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
     def test_physics_joint_multiple_rels(self):
@@ -395,12 +395,12 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         physicsJoint.GetBody1Rel().AddTarget("/xform0")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         physicsJoint.GetBody1Rel().AddTarget("/xform1")
 
         errors = validator.Validate(physicsJoint.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "JointMultiplePrimsRel")
 
     def test_collider_non_uniform_scale(self):
@@ -421,12 +421,12 @@ class TestUsdPhysicsValidation(unittest.TestCase):
             UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
 
             errors = validator.Validate(shape.GetPrim())
-            self.assertTrue(len(errors) == 0)
+            self.assertEqual(len(errors), 0)
 
             shape.AddScaleOp().Set(Gf.Vec3d(1,2,3))
 
             errors = validator.Validate(shape.GetPrim())
-            self.assertTrue(len(errors) == 1)
+            self.assertEqual(len(errors), 1)
             self.assertTrue(errors[0].GetName() == "ColliderNonUniformScale")
 
             stage.RemovePrim(shape.GetPrim().GetPrimPath())
@@ -450,27 +450,27 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         shape.GetWidthsAttr().Set([])
         shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
         shape.GetWidthsAttr().Set([1])
         shape.GetPointsAttr().Set([])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
         shape.GetWidthsAttr().Set([1,3])
         shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
         shape.AddScaleOp().Set(Gf.Vec3d(1,2,3))
@@ -478,7 +478,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderNonUniformScale")
 
         stage.RemovePrim(shape.GetPrim().GetPrimPath())
@@ -499,7 +499,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         shape.GetWidthsAttr().Set([1.0, 2.0])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # only primvars:widths authored, matching count — should pass
         stage = Usd.Stage.CreateInMemory()
@@ -512,7 +512,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         widthsPv.Set([1.0, 2.0])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # both authored, primvars:widths wins — widths attr has wrong count
         # but primvars:widths matches, so should pass
@@ -527,7 +527,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         widthsPv.Set([1.0, 2.0])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # both authored, primvars:widths wins — primvars has wrong count
         # widths attr matches, but primvar takes priority so should fail
@@ -542,7 +542,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         widthsPv.Set([1.0])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
         # neither authored — should fail
@@ -552,7 +552,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
         # indexed primvars:widths — 1 value, 2 indices matching 2 points
@@ -567,13 +567,13 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         widthsPv.SetIndices(Vt.IntArray([0, 0]))
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # indexed primvars:widths — wrong flattened count
         widthsPv.SetIndices(Vt.IntArray([0]))
 
         errors = validator.Validate(shape.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
     def test_plane_collider_static_only(self):
@@ -592,7 +592,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         UsdPhysics.CollisionAPI.Apply(plane.GetPrim())
 
         errors = validator.Validate(plane.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Plane under a dynamic rigid body - should fail
         dynamicBody = UsdGeom.Xform.Define(stage, "/dynamicBody")
@@ -602,21 +602,21 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         UsdPhysics.CollisionAPI.Apply(dynamicPlane.GetPrim())
 
         errors = validator.Validate(dynamicPlane.GetPrim())
-        self.assertTrue(len(errors) == 1)
+        self.assertEqual(len(errors), 1)
         self.assertTrue(errors[0].GetName() == "ColliderPlaneDynamic")
 
         # Plane under a static rigid body (enabled=false) - should pass
         rboAPI.GetRigidBodyEnabledAttr().Set(False)
 
         errors = validator.Validate(dynamicPlane.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
         # Plane under a kinematic rigid body - should pass
         rboAPI.GetRigidBodyEnabledAttr().Set(True)
         rboAPI.GetKinematicEnabledAttr().Set(True)
 
         errors = validator.Validate(dynamicPlane.GetPrim())
-        self.assertTrue(len(errors) == 0)
+        self.assertEqual(len(errors), 0)
 
     def test_rigid_body_mass_api(self):
         validationRegistry = UsdValidation.ValidationRegistry()

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -84,7 +84,7 @@ bool IsDynamicBody(const UsdPrim& usdPrim, bool* outPhysicsAPIFound)
     if (rboAPI)
     {
         {
-            bool isAPISchemaEnabled = false;
+            bool isAPISchemaEnabled = true;
             rboAPI.GetRigidBodyEnabledAttr().Get(&isAPISchemaEnabled);
 
             // Prim is dynamic body off PhysicsAPI is present and enabled

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -117,7 +117,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
             // disabled body may still have an enabled body above it, which
             // this prim belongs to. Remember the nearest disabled body so it
             // can still be reported if no enabled body is found at all.
-            if (disabledBodyPrim)
+            if (!disabledBodyPrim)
             {
                 disabledBodyPrim = parent;
             }
@@ -129,7 +129,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
     // No enabled body above this prim. Report the nearest disabled body, if
     // any, so it is still recognized as belonging to a body that is present
     // but not simulating rather than as a static collision.
-    if (!disabledBodyPrim)
+    if (disabledBodyPrim)
     {
         *outBodyPrimPath = disabledBodyPrim;
     }

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -101,7 +101,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
 {
     bool physicsAPIFound = false;
     UsdPrim parent = usdPrim;
-    UsdPrim disabledBodyPrim = UsdPrim();
+    UsdPrim disabledBodyPrim;
     while (parent != usdPrim.GetStage()->GetPseudoRoot())
     {
         if (IsDynamicBody(parent, &physicsAPIFound))
@@ -117,7 +117,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
             // disabled body may still have an enabled body above it, which
             // this prim belongs to. Remember the nearest disabled body so it
             // can still be reported if no enabled body is found at all.
-            if (disabledBodyPrim == UsdPrim())
+            if (disabledBodyPrim)
             {
                 disabledBodyPrim = parent;
             }
@@ -129,7 +129,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
     // No enabled body above this prim. Report the nearest disabled body, if
     // any, so it is still recognized as belonging to a body that is present
     // but not simulating rather than as a static collision.
-    if (disabledBodyPrim != UsdPrim())
+    if (!disabledBodyPrim)
     {
         *outBodyPrimPath = disabledBodyPrim;
     }

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -101,6 +101,7 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
 {
     bool physicsAPIFound = false;
     UsdPrim parent = usdPrim;
+    UsdPrim disabledBodyPrim = UsdPrim();
     while (parent != usdPrim.GetStage()->GetPseudoRoot())
     {
         if (IsDynamicBody(parent, &physicsAPIFound))
@@ -111,11 +112,26 @@ bool HasDynamicBodyParent(const UsdPrim& usdPrim, UsdPrim* outBodyPrimPath)
 
         if (physicsAPIFound)
         {
-            *outBodyPrimPath = parent;
-            return false;
+            // A disabled rigid body takes no part in simulation, so it does
+            // not own this prim. Keep searching the ancestors: a nested
+            // disabled body may still have an enabled body above it, which
+            // this prim belongs to. Remember the nearest disabled body so it
+            // can still be reported if no enabled body is found at all.
+            if (disabledBodyPrim == UsdPrim())
+            {
+                disabledBodyPrim = parent;
+            }
         }
 
         parent = parent.GetParent();
+    }
+
+    // No enabled body above this prim. Report the nearest disabled body, if
+    // any, so it is still recognized as belonging to a body that is present
+    // but not simulating rather than as a static collision.
+    if (disabledBodyPrim != UsdPrim())
+    {
+        *outBodyPrimPath = disabledBodyPrim;
     }
     return false;
 }
@@ -583,8 +599,12 @@ bool HasEnabledRigidBody(const SdfPath& relPath, const UsdPrim& jointPrim)
         return false;
     }
 
-    bool physicsAPIFound = false;
-    return IsDynamicBody(relPrim, &physicsAPIFound);
+    // A body relationship may target any UsdGeomXformable, not only the prim
+    // carrying the RigidBodyAPI. Joint parsing resolves such a target to its
+    // closest ancestor body, so search the ancestors here as well, otherwise a
+    // joint targeting a collider below a body is reported as bodyless.
+    UsdPrim bodyPrim;
+    return HasDynamicBodyParent(relPrim, &bodyPrim);
 }
 
 


### PR DESCRIPTION
### Description of Change(s)

Per the schema docs, `physics:rigidBodyEnabled = false` means the body takes no part in simulation, which is equivalent to not applying `UsdPhysicsRigidBodyAPI` at all. Every ancestor traversal that resolves which body owns a prim should therefore continue past a disabled body to the nearest enabled one.

This supersedes #4164 and fixes two more traversals that were missed there.

- `ComputeMassProperties` counted colliders with `physics:collisionEnabled = false` toward mass, center of mass and inertia, even though it skipped them as shapes.
- A disabled nested body pruned its subtree, so the colliders below it contributed mass to no body at all.
- `_HasDynamicBodyParent` stopped at a disabled body, so colliders below it were treated as static instead of belonging to the enabled body above.
- `_GetBodyPrim`, which resolves a joint's body relationship, returned the disabled body and never looked at `physics:rigidBodyEnabled` at all.
- `PhysicsJointChecker` only looked for `RigidBodyAPI` on the prim a body relationship targets. A relationship may point at any `UsdGeomXformable`, and joint parsing resolves it to the closest ancestor body, so a joint anchored to a collider under a body was flagged as bodyless while parsing resolved it to a real enabled body.

Before this change, a collider under a disabled inner body under an enabled outer body got three different answers: collider attribution said the outer body, the joint relationship resolved to the disabled inner body, and validation reported an error. All three now resolve to the outer body.

Enabled bodies and colliders relying on the `true` fallback are unaffected. `JointNoEnabledRigidBody` is evaluated per joint rather than per relationship, and is unchanged here: one of the two relationships reaching an enabled body is sufficient, either directly or through an ancestor, so an empty relationship or a non-body target opposite a body does not error.

### Fixes Issue(s)

Supersedes and includes #4164.

### AI Assistance

Developed with AI assistance (Anthropic Claude, primarily Opus 5): the
code, tests, and this description were AI-drafted and then reviewed by
me before submission.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
