### PR TITLE
Updated support for MSVC 2026, add Boost version 1.92 and update conditions

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -812,7 +812,8 @@ BOOST_VERSION_FILES = [
     "include/boost/version.hpp",
     "include/boost-1_80/boost/version.hpp",
     "include/boost-1_82/boost/version.hpp",
-    "include/boost-1_86/boost/version.hpp"
+    "include/boost-1_86/boost/version.hpp",
+    "include/boost-1_92/boost/version.hpp"
 ]
 
 def InstallBoost_Helper(context, force, buildArgs):
@@ -824,9 +825,9 @@ def InstallBoost_Helper(context, force, buildArgs):
     # - Building on MacOS requires v1.82.0 or later for C++17 support starting
     #   with Xcode 15.
     if IsVisualStudio2026OrGreater():
-        BOOST_VERSION = (1, 90, 0)
-        BOOST_SHA256 = "bdc79f179d1a4a60c10fe764172946d0eeafad65e576a8703c4d89d49949973c"
-    if IsVisualStudio2022OrGreater():
+        BOOST_VERSION = (1, 92, 0)
+        BOOST_SHA256 = "c46baee75ed4b558cf6553630d0615a147ed582812917b57e6f0839d1954549f"
+    elif IsVisualStudio2022OrGreater():
         BOOST_VERSION = (1, 86, 0)
         BOOST_SHA256 = "cd20a5694e753683e1dc2ee10e2d1bb11704e65893ebcc6ced234ba68e5d8646"
     elif MacOS():


### PR DESCRIPTION
### Description of Change(s)

Updated support for MSVC 2026, add Boost version 1.92 and update conditions

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Boost for MSVC 2026 was never used due to an 'if' that was supposed to be an 'elif'
Boost V1.90 didn't compile on MSVC 2026, V1.92 does.
Added V1.92 to BOOST_VERSION_FILES

### Checklist

- x[ ] I have created this PR based on the dev branch

- [x ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
