### PR TITLE
Autodesk: [hgiMetal] Disable depth-slope for points

### DIFF
--- a/pxr/imaging/hgiMetal/graphicsPipeline.mm
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.mm
@@ -439,9 +439,14 @@ HgiMetalGraphicsPipeline::BindPipeline(id<MTLRenderCommandEncoder> renderEncoder
     //
     HgiDepthStencilState const & dsState = _descriptor.depthState;
     if (_descriptor.depthState.depthBiasEnabled) {
+        // A point has no depth gradient, so a slope scaled bias should have no
+        // effect, but instead it causes randomly broken depth values.
+        const float slopeScale =
+            (_descriptor.primitiveType == HgiPrimitiveTypePointList)
+                ? 0.0f : dsState.depthBiasSlopeFactor;
         [renderEncoder
             setDepthBias: dsState.depthBiasConstantFactor
-              slopeScale: dsState.depthBiasSlopeFactor
+              slopeScale: slopeScale
                    clamp: 0.0f];
     }
 


### PR DESCRIPTION
### Description of Change(s)
`slopeScale` on points seems to cause incorrect depth values on some Metal implementations, so make sure it's always 0.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
