### PR TITLE
Autodesk: [hdx, hdSt] Fix OIT AOV binding with early fragment tests

### DIFF
--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -836,20 +836,19 @@ HdStResourceRegistry::SubmitComputeWork(HgiSubmitWaitType wait)
 }
 
 void
-HdStResourceRegistry::_CommitTextures()
+HdStResourceRegistry::CommitTextures()
 {
     HdStShaderCode::ResourceContext ctx(this);
 
     const std::set<HdStShaderCodeSharedPtr> shaderCodes =
         _textureHandleRegistry->Commit();
 
-    // Give assoicated HdStShaderCode objects a chance to add buffer
+    // Give associated HdStShaderCode objects a chance to add buffer
     // sources that rely on texture sampler handles (bindless) or
     // texture metadata (e.g., sampling transform for volume fields).
     for (HdStShaderCodeSharedPtr const & shaderCode : shaderCodes) {
         shaderCode->AddResourcesFromTextures(ctx);
     }
-    _renderBufferPool.Commit();
 }
 
 void
@@ -866,7 +865,8 @@ HdStResourceRegistry::_Commit()
     // some computation buffer sources need meta-data from textures
     // (such as the grid transform for an OpenVDB file) or texture
     // handles (for bindless textures).
-    _CommitTextures();
+    CommitTextures();
+    _renderBufferPool.Commit();
 
     {
         HD_TRACE_SCOPE("Resolve");

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -165,6 +165,16 @@ public:
         /// AddResourcesFromTextures.
         HdStShaderCodePtr const &shaderCode);
 
+    /// Commit any texture handles allocated since the last commit,
+    /// creating their GPU texture and sampler resources.
+    ///
+    /// This is normally driven by the commit phase, which runs between the
+    /// tasks' Prepare() and Execute() phases. Call this only when a texture
+    /// handle has to be allocated during Execute(), which would otherwise
+    /// leave it without a sampler object until the next frame's commit.
+    HDST_API
+    void CommitTextures();
+
     /// Allocate texture object.
     ///
     /// The actual allocation of the associated GPU texture and
@@ -564,7 +574,6 @@ protected:
     void _GarbageCollect() override;
 
 private:
-    void _CommitTextures();
     // Wrapper function for BAR allocation
     HdBufferArrayRangeSharedPtr _AllocateBufferArrayRange(
         HdStAggregationStrategy *strategy,

--- a/pxr/imaging/hdx/oitRenderTask.cpp
+++ b/pxr/imaging/hdx/oitRenderTask.cpp
@@ -17,6 +17,7 @@
 
 #include "pxr/imaging/hdSt/renderPass.h"
 #include "pxr/imaging/hdSt/renderPassShader.h"
+#include "pxr/imaging/hdSt/resourceRegistry.h"
 
 #include "pxr/imaging/glf/diagnostic.h"
 
@@ -260,6 +261,16 @@ HdxOitRenderTask::Execute(HdTaskContext* ctx)
         _translucentPassShader->UpdateAovInputTextures(
                 _translucentPassState->GetAovInputBindings(),
                 renderIndex);
+        // The commit phase, which would create the texture and sampler objects
+        // backing the handles allocated above, runs between Prepare() and
+        // Execute(), so it has already happened by now. Commit the new
+        // handles here, otherwise they reach the texture binder without a
+        // sampler object and the depth readback binding is dropped.
+        if (auto* const stResourceRegistry =
+                dynamic_cast<HdStResourceRegistry*>(
+                    renderIndex->GetResourceRegistry().get())) {
+            stResourceRegistry->CommitTextures();
+        }
     }
 
     // Ensure OIT buffer bindings are registered with the shader


### PR DESCRIPTION
### Description of Change(s)

This late `CommitTextures()` call is needed for `hgiWebGPU`.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))