### PR TITLE
Autodesk: [usdview] Explicitly remove fb alpha on Windows

### DIFF
--- a/pxr/usdImaging/usdviewq/qt.py
+++ b/pxr/usdImaging/usdviewq/qt.py
@@ -60,6 +60,10 @@ if PySideModule == 'PySide2':
 
     QGLWidget.InitQGLWidget = initQGLWidget
 
+    # QGLFormat has the alpha channel disabled by default. Note that
+    # setAlphaBufferSize() would implicitly *enable* it, so use setAlpha().
+    QGLFormat.DisableAlphaBuffer = lambda self: self.setAlpha(False)
+
 elif PySideModule == 'PySide6':
     from PySide6 import QtCore, QtGui, QtWidgets, QtOpenGL
     from PySide6.QtOpenGLWidgets import QOpenGLWidget as QGLWidget
@@ -96,6 +100,11 @@ elif PySideModule == 'PySide6':
         self.setFormat(glFormat)
 
     QGLWidget.InitQGLWidget = initQGLWidget
+
+    # QSurfaceFormat leaves the alpha buffer size unspecified (-1), which lets
+    # the platform pick a pixel format that has one; Windows does, which makes
+    # the grabbed framebuffer RGBA instead of RGB. Request none explicitly.
+    QGLFormat.DisableAlphaBuffer = lambda self: self.setAlphaBufferSize(0)
 
 else:
     raise ImportError('Unrecognized PySide module "{}"'.format(PySideModule))

--- a/pxr/usdImaging/usdviewq/stageView.py
+++ b/pxr/usdImaging/usdviewq/stageView.py
@@ -833,9 +833,12 @@ class StageView(QGLWidget):
         self._allowAsync = bool(value)
 
     def __init__(self, parent=None, dataModel=None, makeTimer=Timer):
-        # Note: The default format *disables* the alpha component and so the
-        # default backbuffer uses GL_RGB.
+        # Note: we disable the alpha component so that the backbuffer uses
+        # GL_RGB. Without this, the platform is free to pick a pixel format
+        # that has an alpha channel, which makes grabbed framebuffers RGBA on
+        # some platforms and RGB on others.
         glFormat = QGLFormat()
+        glFormat.DisableAlphaBuffer()
         msaa = os.getenv("USDVIEW_ENABLE_MSAA", "1")
         if msaa == "1":
             glFormat.setSampleBuffers(True)


### PR DESCRIPTION
### Description of Change(s)

Windows outputs alpha in `usdview` capture, but baselines don't have an alpha channel, so that breaks tests that don't use the `PERCEPTUAL` flag.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
