### PR TITLE
Autodesk: [usdview] Fix selection changes not showing up in test screenshots

### DIFF
--- a/pxr/usdImaging/bin/testusdview/testusdview.py
+++ b/pxr/usdImaging/bin/testusdview/testusdview.py
@@ -134,6 +134,11 @@ AppController._processEvents = _processEvents
 def _takeShot(self, fileName, iterations=10, waitForConvergence=False,
               cropToAspectRatio=False):
     self._processEvents(iterations, waitForConvergence)
+    # Force a synchronous repaint, because it's not guaranteed it will always
+    # happen before the shot. This mostly seems to be a Windows issue.
+    if self._stageView:
+        self._stageView.updateSelection()
+        self._stageView.repaint()
     viewportShot = self.GrabViewportShot(cropToAspectRatio=cropToAspectRatio)
     viewportShot.save(fileName, "PNG")
 

--- a/pxr/usdImaging/usdviewq/primTreeWidget.py
+++ b/pxr/usdImaging/usdviewq/primTreeWidget.py
@@ -464,9 +464,11 @@ class PrimTreeWidget(QtWidgets.QTreeWidget):
         use over calling setSelected directly on PrimViewItems."""
         with SelectionEnabler(self._selectionModel):
             for item in added:
-                item.setSelected(True)
+                if item is not None:
+                    item.setSelected(True)
             for item in removed:
-                item.setSelected(False)
+                if item is not None:
+                    item.setSelected(False)
         self._refreshAncestorsOfSelected()
         # This is a big hammer... if we instead built up a list of the
         # ModelIndices of all the changed ancestors, we could instead make
@@ -481,9 +483,11 @@ class PrimTreeWidget(QtWidgets.QTreeWidget):
 
     # Refresh the list of ancestors of selected prims
     def _refreshAncestorsOfSelected(self):
-        selectedItems = [
-            self._appController._getItemAtPath(prim.GetPath())
-            for prim in self._appController._dataModel.selection.getPrims()]
+        selectedItems = []
+        for prim in self._appController._dataModel.selection.getPrims():
+            item = self._appController._getItemAtPath(prim.GetPath())
+            if item is not None:
+                selectedItems.append(item)
 
         self._resetAncestorsOfSelected()
 


### PR DESCRIPTION
### Description of Change(s)

Fixes random `testusdview` failures on Windows, were the selection is outdated in the screenshot. Still not sure exactly why this happens, but this fixes it.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))