### PR TITLE
Make `hdEmbree` not depend on `PXR_BUILD_GPU_SUPPORT`

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -240,11 +240,6 @@ if (${PXR_BUILD_EMBREE_PLUGIN})
         message(STATUS
             "Setting PXR_BUILD_EMBREE_PLUGIN=OFF because PXR_BUILD_IMAGING=OFF")
         set(PXR_BUILD_EMBREE_PLUGIN "OFF" CACHE BOOL "" FORCE)
-    elseif (NOT ${PXR_BUILD_GPU_SUPPORT})
-        message(STATUS
-            "Setting PXR_BUILD_EMBREE_PLUGIN=OFF because "
-            "PXR_BUILD_GPU_SUPPORT=OFF")
-        set(PXR_BUILD_EMBREE_PLUGIN "OFF" CACHE BOOL "" FORCE)
     endif()
 endif()
 

--- a/pxr/imaging/hgi/CMakeLists.txt
+++ b/pxr/imaging/hgi/CMakeLists.txt
@@ -58,11 +58,13 @@ if (WIN32)
     return()
 endif()
 
-pxr_build_test(testHgiCommand
-    LIBRARIES
-        hgi
-        garch
-        tf
-    CPPFILES
-        testenv/testHgiCommand.cpp
-)
+if (${PXR_BUILD_GPU_SUPPORT})
+    pxr_build_test(testHgiCommand
+        LIBRARIES
+            hgi
+            garch
+            tf
+        CPPFILES
+            testenv/testHgiCommand.cpp
+    )
+endif()

--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -1,12 +1,6 @@
 set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hdEmbree)
 
-if (NOT ${PXR_BUILD_GPU_SUPPORT})
-    message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT is OFF")
-    return()
-endif()
-
 pxr_plugin(hdEmbree
    LIBRARIES
         tf
@@ -50,7 +44,7 @@ pxr_plugin(hdEmbree
         overview.dox
 )
 
-if (X11_FOUND OR APPLE)
+if (${PXR_BUILD_GPU_SUPPORT} AND (X11_FOUND OR APPLE))
 pxr_build_test(testHdEmbree
     LIBRARIES
         arch


### PR DESCRIPTION
### Description of Change(s)

Embree is a useful example of an imaging plugin that doesn't require a GPU.  However, it currently early exits if `PXR_BUILD_GPU_SUPPORT` is not enabled.  This PR allows embree to build without GPU support enabled.

Future work should investigate if CPU versions of `testHdEmbree` can be provided.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
