### PR TITLE
Default constructor for UsdGeomBBoxCache Class

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -306,6 +306,17 @@ UsdGeomBBoxCache::UsdGeomBBoxCache(UsdGeomBBoxCache const &other)
 {
 }
 
+UsdGeomBBoxCache::UsdGeomBBoxCache()
+    : _time()
+    , _baseTime()
+    , _includedPurposes()
+    , _ctmCache()
+    , _bboxCache()
+    , _useExtentsHint(false)
+    , _ignoreVisibility(false)
+{
+}
+
 UsdGeomBBoxCache::~UsdGeomBBoxCache() = default;
 
 UsdGeomBBoxCache &

--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -5,6 +5,8 @@
 // https://openusd.org/license.
 //
 #include "pxr/pxr.h"
+#include "pxr/usd/usd/timeCode.h"
+
 #include "pxr/usd/usdGeom/bboxCache.h"
 
 #include "pxr/usd/kind/registry.h"
@@ -307,10 +309,9 @@ UsdGeomBBoxCache::UsdGeomBBoxCache(UsdGeomBBoxCache const &other)
 }
 
 UsdGeomBBoxCache::UsdGeomBBoxCache()
-    : _time()
-    , _baseTime()
+    : _time(UsdTimeCode::Default())
     , _includedPurposes()
-    , _ctmCache()
+    , _ctmCache(UsdTimeCode::Default())
     , _bboxCache()
     , _useExtentsHint(false)
     , _ignoreVisibility(false)

--- a/pxr/usd/usdGeom/bboxCache.h
+++ b/pxr/usd/usdGeom/bboxCache.h
@@ -95,6 +95,10 @@ public:
     USDGEOM_API
     UsdGeomBBoxCache(UsdGeomBBoxCache const &other);
 
+    /// Default constructor
+    USDGEOM_API
+    UsdGeomBBoxCache();
+
     /// Destructor
     USDGEOM_API
     ~UsdGeomBBoxCache();


### PR DESCRIPTION
### Description of Change(s)

Added a default constructor for UsdGeomBBoxCache class.
Use the default `UsdTimeCode` as recommended in the docs for `_time` and `_ctmCache`.

### Fixes Issue

Related Issue : https://github.com/PixarAnimationStudios/OpenUSD/issues/136

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
