### PR TITLE
Replace `PUBLIC_{HEADERS,CLASSES}` with `PRIVATE` for plugins

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -18,8 +18,10 @@ pxr_plugin(hdEmbree
         hio
         Embree::embree
 
-    PUBLIC_CLASSES
+    PRIVATE_CLASSES
         config
+        debugCodes
+        implicitSurfaceSceneIndexPlugin
         instancer
         light
         lightSamplers
@@ -34,14 +36,10 @@ pxr_plugin(hdEmbree
         renderPass
         sampler
 
-    PUBLIC_HEADERS
+    PRIVATE_HEADERS
         context.h
         renderParam.h
         pxrPbrt/pbrtUtils.h
-
-    PRIVATE_CLASSES
-        debugCodes
-        implicitSurfaceSceneIndexPlugin
 
     RESOURCE_FILES
         plugInfo.json

--- a/pxr/imaging/plugin/hdStorm/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdStorm/CMakeLists.txt
@@ -21,7 +21,7 @@ pxr_plugin(hdStorm
     INCLUDE_DIRS
         ${OPENSUBDIV_INCLUDE_DIR}
 
-    PUBLIC_CLASSES
+    PRIVATE_CLASSES
         rendererPlugin
 
     RESOURCE_FILES

--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -29,7 +29,7 @@ pxr_plugin(sdrOsl
         ${OIIO_INCLUDE_DIRS}
         ${__OSL_IMATH_INCLUDE}
 
-    PUBLIC_CLASSES
+    PRIVATE_CLASSES
         oslParser
 
     PRIVATE_HEADERS


### PR DESCRIPTION
### Description of Change(s)

While investigating the feasibility of using the `MODULE` cmake library type to facilitate exporting targets for plugins, I observed that several plugins provided `PUBLIC_HEADERS` and `PUBLIC_CLASSES`.  (This was previously noted in #4079 as well).

Usage of `pxr_plugin` is for shared libraries that [aren't intended to be linked externally linked against](https://github.com/PixarAnimationStudios/OpenUSD/blob/23b83aa8c479ec0f8b8b11dada50e764af6f3645/cmake/macros/Private.cmake#L1471).  It's not immediately obvious that these headers are useable outside of the `pxr` project and that their being tagged as `PUBLIC_` wasn't an accident.

This change removes these headers from the installed `include` directory.

As an aside, I could imagine that for pure organizational purposes, there being a case for pure public headers without any linkage requirements, but that doesn't appear what these are. Future changes might consider disallowing the `PUBLIC_` arguments from `pxr_plugin`.  Given that `pxr_library` offers "libraries with plugin semantics" (libraries with resources and `plugInfo.json`), there doesn't seem to be a reason to also offer "plugins with semi-library semantics".

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
