### PR TITLE
Move schemaRegistry prim definition lookups out of line

### DIFF
--- a/pxr/usd/usd/schemaRegistry.cpp
+++ b/pxr/usd/usd/schemaRegistry.cpp
@@ -2166,5 +2166,40 @@ Usd_GetAPISchemaPluginApplyToInfoForType(
     }
 }
 
+// These lookups live in the implementation rather than in the class body:
+// their bodies instantiate map value types that own a unique_ptr to the
+// incomplete UsdPrimDefinition. When a C++20 translation unit parses the
+// header, libstdc++'s explicitly-defaulted pair constructor evaluates the
+// value types' destructibility, which requires a complete UsdPrimDefinition.
+const UsdPrimDefinition*
+UsdSchemaRegistry::FindAbstractPrimDefinition(const TfToken &typeName) const
+{
+    const auto it = _abstractTypedPrimDefinitions.find(typeName);
+    return it != _abstractTypedPrimDefinitions.end() ?
+        it->second.get() : nullptr;
+}
+
+const UsdPrimDefinition*
+UsdSchemaRegistry::FindConcretePrimDefinition(const TfToken &typeName) const
+{
+    const auto it = _concreteTypedPrimDefinitions.find(typeName);
+    return it != _concreteTypedPrimDefinitions.end() ?
+        it->second.get() : nullptr;
+}
+
+const UsdPrimDefinition *
+UsdSchemaRegistry::FindAppliedAPIPrimDefinition(const TfToken &typeName) const
+{
+    const auto it = _appliedAPIPrimDefinitions.find(typeName);
+    return it != _appliedAPIPrimDefinitions.end() ?
+        it->second.primDef.get() : nullptr;
+}
+
+const UsdPrimDefinition *
+UsdSchemaRegistry::GetEmptyPrimDefinition() const
+{
+    return _emptyPrimDefinition;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/usd/usd/schemaRegistry.h
+++ b/pxr/usd/usd/schemaRegistry.h
@@ -496,37 +496,27 @@ public:
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered abstract typed schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition* FindAbstractPrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _abstractTypedPrimDefinitions.find(typeName);
-        return it != _abstractTypedPrimDefinitions.end() ?
-            it->second.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered concrete typed schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition* FindConcretePrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _concreteTypedPrimDefinitions.find(typeName);
-        return it != _concreteTypedPrimDefinitions.end() ? 
-            it->second.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered applied API schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition *FindAppliedAPIPrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _appliedAPIPrimDefinitions.find(typeName);
-        return it != _appliedAPIPrimDefinitions.end() ?
-            it->second.primDef.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Returns the empty prim definition.
-    const UsdPrimDefinition *GetEmptyPrimDefinition() const {
-        return _emptyPrimDefinition;
-    }
+    USD_API
+    const UsdPrimDefinition *GetEmptyPrimDefinition() const;
 
     /// Composes and returns a new UsdPrimDefinition from the given \p primType
     /// and list of \p appliedSchemas. This prim definition will contain a union


### PR DESCRIPTION
Move the four UsdSchemaRegistry prim definition lookups (FindAbstractPrimDefinition, FindConcretePrimDefinition, FindAppliedAPIPrimDefinition, GetEmptyPrimDefinition) out of the class body into schemaRegistry.cpp, marked USD_API.

## Prior behavior

Their inline bodies call find() on maps whose value types own a std::unique_ptr<UsdPrimDefinition>, and are instantiated at class definition end. With libstdc++ 13 compiled as C++20 or newer, the explicitly-defaulted std::pair constructor evaluates __is_implicitly_default_constructible of the value types, which instantiates their destructors and therefore requires a complete UsdPrimDefinition - but the header only forward-declares it. Any C++20 translation unit including pxr/usd/usd/schemaRegistry.h then fails with:

`
/usr/include/c++/13/bits/unique_ptr.h:97:16: error: invalid application of 'sizeof' to an incomplete type 'pxrInternal_v0_26_8__pxrReserved__::UsdPrimDefinition'
`

With C++17 the failing pair constructor overload does not exist, which is why building USD itself does not hit this; only C++20+ consumers of the headers do.

## New behavior

The four lookups live in schemaRegistry.cpp (where primDefinition.h is already included), so the header stays parseable for C++20 consumers. Behavior of the library is unchanged.

## Testing

- Reproduced the failure with g++ 13 -std=c++23 -fsyntax-only over a TU that includes schemaRegistry.h (fails before, compiles after the change).
- The same change ships as a patch in microsoft/vcpkg's usd port, where it fixes the C++20 consumer build on x64-linux-clang-20: microsoft/vcpkg#53884.

## AI disclosure

This change was prepared with the assistance of an AI coding agent (GLM via opencode); the contribution is covered by the submitter's CLA.